### PR TITLE
Temperature/entropy modes in nuclear EoS

### DIFF
--- a/include/EoS.h
+++ b/include/EoS.h
@@ -33,6 +33,7 @@ struct EoS_t
    EoS_DE2P_t DensEint2Pres_FuncPtr;
    EoS_DP2E_t DensPres2Eint_FuncPtr;
    EoS_DP2C_t DensPres2CSqr_FuncPtr;
+   EoS_GENE_t General_FuncPtr;
 
 // table pointers
    real **Table;

--- a/include/Global.h
+++ b/include/Global.h
@@ -239,10 +239,12 @@ extern int    EoS_AuxArray_Int[EOS_NAUX_MAX];
 extern EoS_DE2P_t EoS_DensEint2Pres_CPUPtr;
 extern EoS_DP2E_t EoS_DensPres2Eint_CPUPtr;
 extern EoS_DP2C_t EoS_DensPres2CSqr_CPUPtr;
+extern EoS_GENE_t EoS_General_CPUPtr;
 #ifdef GPU
 extern EoS_DE2P_t EoS_DensEint2Pres_GPUPtr;
 extern EoS_DP2E_t EoS_DensPres2Eint_GPUPtr;
 extern EoS_DP2C_t EoS_DensPres2CSqr_GPUPtr;
+extern EoS_GENE_t EoS_General_GPUPtr;
 #endif
 extern EoS_t EoS;
 #endif // HYDRO

--- a/include/Typedef.h
+++ b/include/Typedef.h
@@ -383,14 +383,18 @@ const SF_CreateStarScheme_t
 
 
 // function pointers
-typedef real (*EoS_DE2P_t)( const real Dens, const real Eint, const real Passive[], const double AuxArray_Flt[],
-                            const int AuxArray_Int[], const real *const Table[EOS_NTABLE_MAX] );
-typedef real (*EoS_DP2E_t)( const real Dens, const real Pres, const real Passive[], const double AuxArray_Flt[],
-                            const int AuxArray_Int[], const real *const Table[EOS_NTABLE_MAX] );
-typedef real (*EoS_DP2C_t)( const real Dens, const real Pres, const real Passive[], const double AuxArray_Flt[],
-                            const int AuxArray_Int[], const real *const Table[EOS_NTABLE_MAX] );
-typedef void (*EoS_GENE_t)( const int Mode, real Out[], const real In[], const double AuxArray_Flt[],
-                            const int AuxArray_Int[], const real *const Table[EOS_NTABLE_MAX] );
+typedef real (*EoS_DE2P_t)( const real Dens, const real Eint, const real Passive[],
+                            const double AuxArray_Flt[], const int AuxArray_Int[],
+                            const real *const Table[EOS_NTABLE_MAX], real ExtraInOut[] );
+typedef real (*EoS_DP2E_t)( const real Dens, const real Pres, const real Passive[],
+                            const double AuxArray_Flt[], const int AuxArray_Int[],
+                            const real *const Table[EOS_NTABLE_MAX], real ExtraInOut[] );
+typedef real (*EoS_DP2C_t)( const real Dens, const real Pres, const real Passive[],
+                            const double AuxArray_Flt[], const int AuxArray_Int[],
+                            const real *const Table[EOS_NTABLE_MAX], real ExtraInOut[] );
+typedef void (*EoS_GENE_t)( const int Mode, real Out[], const real In[],
+                            const double AuxArray_Flt[], const int AuxArray_Int[],
+                            const real *const Table[EOS_NTABLE_MAX] );
 typedef void (*ExtAcc_t)( real Acc[], const double x, const double y, const double z, const double Time,
                           const double UserArray[] );
 typedef real (*ExtPot_t)( const double x, const double y, const double z, const double Time,

--- a/include/Typedef.h
+++ b/include/Typedef.h
@@ -389,6 +389,8 @@ typedef real (*EoS_DP2E_t)( const real Dens, const real Pres, const real Passive
                             const int AuxArray_Int[], const real *const Table[EOS_NTABLE_MAX] );
 typedef real (*EoS_DP2C_t)( const real Dens, const real Pres, const real Passive[], const double AuxArray_Flt[],
                             const int AuxArray_Int[], const real *const Table[EOS_NTABLE_MAX] );
+typedef void (*EoS_GENE_t)( const int Mode, real Out[], const real In[], const double AuxArray_Flt[],
+                            const int AuxArray_Int[], const real *const Table[EOS_NTABLE_MAX] );
 typedef void (*ExtAcc_t)( real Acc[], const double x, const double y, const double z, const double Time,
                           const double UserArray[] );
 typedef real (*ExtPot_t)( const double x, const double y, const double z, const double Time,

--- a/src/Auxiliary/Aux_ComputeProfile.cpp
+++ b/src/Auxiliary/Aux_ComputeProfile.cpp
@@ -466,7 +466,7 @@ void Aux_ComputeProfile( Profile_t *Prof[], const double Center[], const double 
                               const real Pres = Hydro_DensEntropy2Pres( Dens, Enpy, EoS_AuxArray_Flt[1],
                                                                         CheckMinPres_No, NULL_REAL );
                               const real Eint = EoS_DensPres2Eint_CPUPtr( Dens, Pres, Passive, EoS_AuxArray_Flt,
-                                                                          EoS_AuxArray_Int, h_EoS_Table );
+                                                                          EoS_AuxArray_Int, h_EoS_Table, NULL );
 #                             elif ( DUAL_ENERGY == DE_EINT )
 #                             error : DE_EINT is NOT supported yet !!
 #                             endif

--- a/src/EoS/EoS_Init.cpp
+++ b/src/EoS/EoS_Init.cpp
@@ -74,6 +74,7 @@ void EoS_Init()
    EoS.DensEint2Pres_FuncPtr = EoS_DensEint2Pres_GPUPtr;
    EoS.DensPres2Eint_FuncPtr = EoS_DensPres2Eint_GPUPtr;
    EoS.DensPres2CSqr_FuncPtr = EoS_DensPres2CSqr_GPUPtr;
+   EoS.General_FuncPtr       = EoS_General_GPUPtr;
 
    CUAPI_SetConstMemory_EoS();
 
@@ -82,6 +83,7 @@ void EoS_Init()
    EoS.DensEint2Pres_FuncPtr = EoS_DensEint2Pres_CPUPtr;
    EoS.DensPres2Eint_FuncPtr = EoS_DensPres2Eint_CPUPtr;
    EoS.DensPres2CSqr_FuncPtr = EoS_DensPres2CSqr_CPUPtr;
+   EoS.General_FuncPtr       = EoS_General_CPUPtr;
 
    EoS.AuxArrayDevPtr_Flt    = EoS_AuxArray_Flt;
    EoS.AuxArrayDevPtr_Int    = EoS_AuxArray_Int;

--- a/src/EoS/Gamma/CPU_EoS_Gamma.cpp
+++ b/src/EoS/Gamma/CPU_EoS_Gamma.cpp
@@ -81,12 +81,14 @@ void EoS_SetAuxArray_Gamma( double AuxArray_Flt[], int AuxArray_Int[] )
 //                Passive    : Passive scalars (must not used here)
 //                AuxArray_* : Auxiliary arrays (see the Note above)
 //                Table      : EoS tables
+//                ExtraInOut : Useless for this EoS
 //
 // Return      :  Gas pressure
 //-------------------------------------------------------------------------------------------------------
 GPU_DEVICE_NOINLINE
-static real EoS_DensEint2Pres_Gamma( const real Dens, const real Eint, const real Passive[], const double AuxArray_Flt[],
-                                     const int AuxArray_Int[], const real *const Table[EOS_NTABLE_MAX] )
+static real EoS_DensEint2Pres_Gamma( const real Dens, const real Eint, const real Passive[],
+                                     const double AuxArray_Flt[], const int AuxArray_Int[],
+                                     const real *const Table[EOS_NTABLE_MAX], real ExtraInOut[] )
 {
 
 // check
@@ -125,12 +127,14 @@ static real EoS_DensEint2Pres_Gamma( const real Dens, const real Eint, const rea
 //                Passive    : Passive scalars (must not used here)
 //                AuxArray_* : Auxiliary arrays (see the Note above)
 //                Table      : EoS tables
+//                ExtraInOut : Useless for this EoS
 //
 // Return      :  Gas internal energy density
 //-------------------------------------------------------------------------------------------------------
 GPU_DEVICE_NOINLINE
-static real EoS_DensPres2Eint_Gamma( const real Dens, const real Pres, const real Passive[], const double AuxArray_Flt[],
-                                     const int AuxArray_Int[], const real *const Table[EOS_NTABLE_MAX] )
+static real EoS_DensPres2Eint_Gamma( const real Dens, const real Pres, const real Passive[],
+                                     const double AuxArray_Flt[], const int AuxArray_Int[],
+                                     const real *const Table[EOS_NTABLE_MAX], real ExtraInOut[] )
 {
 
 // check
@@ -169,12 +173,14 @@ static real EoS_DensPres2Eint_Gamma( const real Dens, const real Pres, const rea
 //                Passive    : Passive scalars (must not used here)
 //                AuxArray_* : Auxiliary arrays (see the Note above)
 //                Table      : EoS tables
+//                ExtraInOut : Useless for this EoS
 //
 // Return      :  Sound speed square
 //-------------------------------------------------------------------------------------------------------
 GPU_DEVICE_NOINLINE
-static real EoS_DensPres2CSqr_Gamma( const real Dens, const real Pres, const real Passive[], const double AuxArray_Flt[],
-                                     const int AuxArray_Int[], const real *const Table[EOS_NTABLE_MAX] )
+static real EoS_DensPres2CSqr_Gamma( const real Dens, const real Pres, const real Passive[],
+                                     const double AuxArray_Flt[], const int AuxArray_Int[],
+                                     const real *const Table[EOS_NTABLE_MAX], real ExtraInOut[] )
 {
 
 // check

--- a/src/EoS/Gamma/CPU_EoS_Gamma.cpp
+++ b/src/EoS/Gamma/CPU_EoS_Gamma.cpp
@@ -17,7 +17,7 @@
 
 3. Three steps are required to implement an EoS
 
-   I.   Set an EoS auxiliary array
+   I.   Set EoS auxiliary arrays
    II.  Implement EoS conversion functions
    III. Set EoS initialization functions
 ********************************************************/
@@ -25,7 +25,7 @@
 
 
 // =============================================
-// I. Set an EoS auxiliary array
+// I. Set EoS auxiliary arrays
 // =============================================
 
 //-------------------------------------------------------------------------------------------------------
@@ -66,6 +66,7 @@ void EoS_SetAuxArray_Gamma( double AuxArray_Flt[], int AuxArray_Int[] )
 //     (1) EoS_DensEint2Pres_*
 //     (2) EoS_DensPres2Eint_*
 //     (3) EoS_DensPres2CSqr_*
+//     (4) EoS_General_* [OPTIONAL]
 // =============================================
 
 //-------------------------------------------------------------------------------------------------------
@@ -201,6 +202,33 @@ static real EoS_DensPres2CSqr_Gamma( const real Dens, const real Pres, const rea
 
 
 
+//-------------------------------------------------------------------------------------------------------
+// Function    :  EoS_General_Gamma
+// Description :  General EoS converter: In[] -> Out[]
+//
+// Note        :  1. See EoS_DensEint2Pres_Gamma()
+//                2. In[] and Out[] must NOT overlap
+//                3. Useless for this EoS
+//
+// Parameter   :  Mode       : To support multiple modes in this general converter
+//                Out        : Output array
+//                In         : Input array
+//                AuxArray_* : Auxiliary arrays (see the Note above)
+//                Table      : EoS tables
+//
+// Return      :  Out[]
+//-------------------------------------------------------------------------------------------------------
+GPU_DEVICE_NOINLINE
+static void EoS_General_Gamma( const int Mode, real Out[], const real In[], const double AuxArray_Flt[],
+                               const int AuxArray_Int[], const real *const Table[EOS_NTABLE_MAX] )
+{
+
+// not used by this EoS
+
+} // FUNCTION : EoS_General_Gamma
+
+
+
 // =============================================
 // III. Set EoS initialization functions
 // =============================================
@@ -214,6 +242,7 @@ static real EoS_DensPres2CSqr_Gamma( const real Dens, const real Pres, const rea
 FUNC_SPACE EoS_DE2P_t EoS_DensEint2Pres_Ptr = EoS_DensEint2Pres_Gamma;
 FUNC_SPACE EoS_DP2E_t EoS_DensPres2Eint_Ptr = EoS_DensPres2Eint_Gamma;
 FUNC_SPACE EoS_DP2C_t EoS_DensPres2CSqr_Ptr = EoS_DensPres2CSqr_Gamma;
+FUNC_SPACE EoS_GENE_t EoS_General_Ptr       = EoS_General_Gamma;
 
 //-----------------------------------------------------------------------------------------
 // Function    :  EoS_SetCPU/GPUFunc_Gamma
@@ -231,29 +260,35 @@ FUNC_SPACE EoS_DP2C_t EoS_DensPres2CSqr_Ptr = EoS_DensPres2CSqr_Gamma;
 // Parameter   :  EoS_DensEint2Pres_CPU/GPUPtr : CPU/GPU function pointers to be set
 //                EoS_DensPres2Eint_CPU/GPUPtr : ...
 //                EoS_DensPres2CSqr_CPU/GPUPtr : ...
+//                EoS_General_CPU/GPUPtr       : ...
 //
-// Return      :  EoS_DensEint2Pres_CPU, EoS_DensPres2Eint_CPU/GPUPtr, EoS_DensPres2CSqr_CPU/GPUPtr
+// Return      :  EoS_DensEint2Pres_CPU/GPUPtr, EoS_DensPres2Eint_CPU/GPUPtr,
+//                EoS_DensPres2CSqr_CPU/GPUPtr, EoS_General_CPU/GPUPtr
 //-----------------------------------------------------------------------------------------
 #ifdef __CUDACC__
 __host__
 void EoS_SetGPUFunc_Gamma( EoS_DE2P_t &EoS_DensEint2Pres_GPUPtr,
                            EoS_DP2E_t &EoS_DensPres2Eint_GPUPtr,
-                           EoS_DP2C_t &EoS_DensPres2CSqr_GPUPtr )
+                           EoS_DP2C_t &EoS_DensPres2CSqr_GPUPtr,
+                           EoS_GENE_t &EoS_General_GPUPtr )
 {
    CUDA_CHECK_ERROR(  cudaMemcpyFromSymbol( &EoS_DensEint2Pres_GPUPtr, EoS_DensEint2Pres_Ptr, sizeof(EoS_DE2P_t) )  );
    CUDA_CHECK_ERROR(  cudaMemcpyFromSymbol( &EoS_DensPres2Eint_GPUPtr, EoS_DensPres2Eint_Ptr, sizeof(EoS_DP2E_t) )  );
    CUDA_CHECK_ERROR(  cudaMemcpyFromSymbol( &EoS_DensPres2CSqr_GPUPtr, EoS_DensPres2CSqr_Ptr, sizeof(EoS_DP2C_t) )  );
+   CUDA_CHECK_ERROR(  cudaMemcpyFromSymbol( &EoS_General_GPUPtr,       EoS_General_Ptr,       sizeof(EoS_GENE_t) )  );
 }
 
 #else // #ifdef __CUDACC__
 
 void EoS_SetCPUFunc_Gamma( EoS_DE2P_t &EoS_DensEint2Pres_CPUPtr,
                            EoS_DP2E_t &EoS_DensPres2Eint_CPUPtr,
-                           EoS_DP2C_t &EoS_DensPres2CSqr_CPUPtr )
+                           EoS_DP2C_t &EoS_DensPres2CSqr_CPUPtr,
+                           EoS_GENE_t &EoS_General_CPUPtr )
 {
    EoS_DensEint2Pres_CPUPtr = EoS_DensEint2Pres_Ptr;
    EoS_DensPres2Eint_CPUPtr = EoS_DensPres2Eint_Ptr;
    EoS_DensPres2CSqr_CPUPtr = EoS_DensPres2CSqr_Ptr;
+   EoS_General_CPUPtr       = EoS_General_Ptr;
 }
 
 #endif // #ifdef __CUDACC__ ... else ...
@@ -264,16 +299,16 @@ void EoS_SetCPUFunc_Gamma( EoS_DE2P_t &EoS_DensEint2Pres_CPUPtr,
 
 // local function prototypes
 void EoS_SetAuxArray_Gamma( double [], int [] );
-void EoS_SetCPUFunc_Gamma( EoS_DE2P_t &, EoS_DP2E_t &, EoS_DP2C_t & );
+void EoS_SetCPUFunc_Gamma( EoS_DE2P_t &, EoS_DP2E_t &, EoS_DP2C_t &, EoS_GENE_t & );
 #ifdef GPU
-void EoS_SetGPUFunc_Gamma( EoS_DE2P_t &, EoS_DP2E_t &, EoS_DP2C_t & );
+void EoS_SetGPUFunc_Gamma( EoS_DE2P_t &, EoS_DP2E_t &, EoS_DP2C_t &, EoS_GENE_t & );
 #endif
 
 //-----------------------------------------------------------------------------------------
 // Function    :  EoS_Init_Gamma
 // Description :  Initialize EoS
 //
-// Note        :  1. Set an auxiliary array by invoking EoS_SetAuxArray_*()
+// Note        :  1. Set auxiliary arrays by invoking EoS_SetAuxArray_*()
 //                   --> It will be copied to GPU automatically in CUAPI_SetConstMemory()
 //                2. Set the CPU/GPU EoS routines by invoking EoS_SetCPU/GPUFunc_*()
 //                3. Invoked by EoS_Init()
@@ -288,9 +323,11 @@ void EoS_Init_Gamma()
 {
 
    EoS_SetAuxArray_Gamma( EoS_AuxArray_Flt, EoS_AuxArray_Int );
-   EoS_SetCPUFunc_Gamma( EoS_DensEint2Pres_CPUPtr, EoS_DensPres2Eint_CPUPtr, EoS_DensPres2CSqr_CPUPtr );
+   EoS_SetCPUFunc_Gamma( EoS_DensEint2Pres_CPUPtr, EoS_DensPres2Eint_CPUPtr,
+                         EoS_DensPres2CSqr_CPUPtr, EoS_General_CPUPtr );
 #  ifdef GPU
-   EoS_SetGPUFunc_Gamma( EoS_DensEint2Pres_GPUPtr, EoS_DensPres2Eint_GPUPtr, EoS_DensPres2CSqr_GPUPtr );
+   EoS_SetGPUFunc_Gamma( EoS_DensEint2Pres_GPUPtr, EoS_DensPres2Eint_GPUPtr,
+                         EoS_DensPres2CSqr_GPUPtr, EoS_General_GPUPtr );
 #  endif
 
 } // FUNCTION : EoS_Init_Gamma

--- a/src/EoS/Isothermal/CPU_EoS_Isothermal.cpp
+++ b/src/EoS/Isothermal/CPU_EoS_Isothermal.cpp
@@ -86,12 +86,14 @@ void EoS_SetAuxArray_Isothermal( double AuxArray_Flt[], int AuxArray_Int[] )
 //                Passive    : Passive scalars
 //                AuxArray_* : Auxiliary arrays (see the Note above)
 //                Table      : EoS tables
+//                ExtraInOut : Useless for this EoS
 //
 // Return      :  Gas pressure
 //-------------------------------------------------------------------------------------------------------
 GPU_DEVICE_NOINLINE
-static real EoS_DensEint2Pres_Isothermal( const real Dens, const real Eint, const real Passive[], const double AuxArray_Flt[],
-                                          const int AuxArray_Int[], const real *const Table[EOS_NTABLE_MAX] )
+static real EoS_DensEint2Pres_Isothermal( const real Dens, const real Eint, const real Passive[],
+                                          const double AuxArray_Flt[], const int AuxArray_Int[],
+                                          const real *const Table[EOS_NTABLE_MAX], real ExtraInOut[] )
 {
 
 // check
@@ -124,12 +126,14 @@ static real EoS_DensEint2Pres_Isothermal( const real Dens, const real Eint, cons
 //                Passive    : Passive scalars
 //                AuxArray_* : Auxiliary arrays (see the Note above)
 //                Table      : EoS tables
+//                ExtraInOut : Useless for this EoS
 //
 // Return      :  Gas internal energy density
 //-------------------------------------------------------------------------------------------------------
 GPU_DEVICE_NOINLINE
-static real EoS_DensPres2Eint_Isothermal( const real Dens, const real Pres, const real Passive[], const double AuxArray_Flt[],
-                                          const int AuxArray_Int[], const real *const Table[EOS_NTABLE_MAX] )
+static real EoS_DensPres2Eint_Isothermal( const real Dens, const real Pres, const real Passive[],
+                                          const double AuxArray_Flt[], const int AuxArray_Int[],
+                                          const real *const Table[EOS_NTABLE_MAX], real ExtraInOut[] )
 {
 
 // check
@@ -161,12 +165,14 @@ static real EoS_DensPres2Eint_Isothermal( const real Dens, const real Pres, cons
 //                Passive    : Passive scalars
 //                AuxArray_* : Auxiliary arrays (see the Note above)
 //                Table      : EoS tables
+//                ExtraInOut : Useless for this EoS
 //
 // Return      :  Sound speed square
 //-------------------------------------------------------------------------------------------------------
 GPU_DEVICE_NOINLINE
-static real EoS_DensPres2CSqr_Isothermal( const real Dens, const real Pres, const real Passive[], const double AuxArray_Flt[],
-                                          const int AuxArray_Int[], const real *const Table[EOS_NTABLE_MAX] )
+static real EoS_DensPres2CSqr_Isothermal( const real Dens, const real Pres, const real Passive[],
+                                          const double AuxArray_Flt[], const int AuxArray_Int[],
+                                          const real *const Table[EOS_NTABLE_MAX], real ExtraInOut[] )
 {
 
 // check

--- a/src/EoS/Isothermal/CPU_EoS_Isothermal.cpp
+++ b/src/EoS/Isothermal/CPU_EoS_Isothermal.cpp
@@ -198,7 +198,7 @@ static real EoS_DensPres2CSqr_Isothermal( const real Dens, const real Pres, cons
 //                3. Useless for this EoS
 //
 // Parameter   :  Mode       : To support multiple modes in this general converter
-//                           : Output array
+//                Out        : Output array
 //                In         : Input array
 //                AuxArray_* : Auxiliary arrays (see the Note above)
 //                Table      : EoS tables

--- a/src/EoS/Nuclear/CPU_EoS_Nuclear.cpp
+++ b/src/EoS/Nuclear/CPU_EoS_Nuclear.cpp
@@ -153,13 +153,15 @@ bool Nuc_Overflow( const real x )
 //                Passive_Code : Passive scalars             (in code unit)
 //                AuxArray_*   : Auxiliary arrays (see the Note above)
 //                Table        : EoS tables
+//                ExtraInOut   : Array to store extra input and output variables if required
+//                               --> Optional and only used when it is not NULL
 //
 // Return      :  Gas pressure (in code unit)
 //-------------------------------------------------------------------------------------------------------
 GPU_DEVICE_NOINLINE
 static real EoS_DensEint2Pres_Nuclear( const real Dens_Code, const real Eint_Code, const real Passive_Code[],
                                        const double AuxArray_Flt[], const int AuxArray_Int[],
-                                       const real *const Table[EOS_NTABLE_MAX] )
+                                       const real *const Table[EOS_NTABLE_MAX], real ExtraInOut[] )
 {
 
 // check
@@ -245,6 +247,15 @@ static real EoS_DensEint2Pres_Nuclear( const real Dens_Code, const real Eint_Cod
 #  endif // GAMER_DEBUG
 
 
+// store extra output variables if required
+   /*
+   if ( ExtraInOut != NULL )
+   {
+      ExtraInOut[...] = ...;
+   }
+   */
+
+
    return Pres_Code;
 
 } // FUNCTION : EoS_DensEint2Pres_Nuclear
@@ -262,13 +273,15 @@ static real EoS_DensEint2Pres_Nuclear( const real Dens_Code, const real Eint_Cod
 //                Passive_Code : Passive scalars  (in code unit)
 //                AuxArray_*   : Auxiliary arrays (see the Note above)
 //                Table        : EoS tables
+//                ExtraInOut   : Array to store extra input and output variables if required
+//                               --> Optional and only used when it is not NULL
 //
 // Return      :  Gas internal energy density (in code unit)
 //-------------------------------------------------------------------------------------------------------
 GPU_DEVICE_NOINLINE
 static real EoS_DensPres2Eint_Nuclear( const real Dens_Code, const real Pres_Code, const real Passive_Code[],
                                        const double AuxArray_Flt[], const int AuxArray_Int[],
-                                       const real *const Table[EOS_NTABLE_MAX] )
+                                       const real *const Table[EOS_NTABLE_MAX], real ExtraInOut[] )
 {
 
 // check
@@ -355,6 +368,15 @@ static real EoS_DensPres2Eint_Nuclear( const real Dens_Code, const real Pres_Cod
 #  endif // GAMER_DEBUG
 
 
+// store extra output variables if required
+   /*
+   if ( ExtraInOut != NULL )
+   {
+      ExtraInOut[...] = ...;
+   }
+   */
+
+
    return Eint_Code;
 
 } // FUNCTION : EoS_DensPres2Eint_Nuclear
@@ -372,13 +394,15 @@ static real EoS_DensPres2Eint_Nuclear( const real Dens_Code, const real Pres_Cod
 //                Passive_Code : Passive scalars  (in code unit)
 //                AuxArray_*   : Auxiliary arrays (see the Note above)
 //                Table        : EoS tables
+//                ExtraInOut   : Array to store extra input and output variables if required
+//                               --> Optional and only used when it is not NULL
 //
 // Return      :  Sound speed square (in code unit)
 //-------------------------------------------------------------------------------------------------------
 GPU_DEVICE_NOINLINE
 static real EoS_DensPres2CSqr_Nuclear( const real Dens_Code, const real Pres_Code, const real Passive_Code[],
                                        const double AuxArray_Flt[], const int AuxArray_Int[],
-                                       const real *const Table[EOS_NTABLE_MAX] )
+                                       const real *const Table[EOS_NTABLE_MAX], real ExtraInOut[] )
 {
 
 // check
@@ -461,6 +485,15 @@ static real EoS_DensPres2CSqr_Nuclear( const real Dens_Code, const real Pres_Cod
       printf( "        EoS error code: %d\n", Err );
    }
 #  endif // GAMER_DEBUG
+
+
+// store extra output variables if required
+   /*
+   if ( ExtraInOut != NULL )
+   {
+      ExtraInOut[...] = ...;
+   }
+   */
 
 
    return Cs2_Code;

--- a/src/EoS/Nuclear/CPU_EoS_Nuclear.cpp
+++ b/src/EoS/Nuclear/CPU_EoS_Nuclear.cpp
@@ -545,6 +545,17 @@ static void EoS_General_Nuclear( const int Mode, real Out[], const real In[], co
 #  endif // GAMER_DEBUG
 
 
+   const real EnergyShift = AuxArray_Flt[NUC_AUX_ESHIFT    ];
+   const real Dens2CGS    = AuxArray_Flt[NUC_AUX_DENS2CGS  ];
+   const real Kelvin2MeV  = AuxArray_Flt[NUC_AUX_KELVIN2MEV];
+   const real sEint2Code  = AuxArray_Flt[NUC_AUX_VSQR2CODE ];
+
+   const int  NRho        = AuxArray_Int[NUC_AUX_NRHO ];
+   const int  NEps        = AuxArray_Int[NUC_AUX_NEPS ];
+   const int  NYe         = AuxArray_Int[NUC_AUX_NYE  ];
+   const int  NMode       = AuxArray_Int[NUC_AUX_NMODE];
+
+
    switch ( Mode )
    {
 //    temperature mode
@@ -569,15 +580,6 @@ static void EoS_General_Nuclear( const int Mode, real Out[], const real In[], co
                     Ye, __FILE__, __LINE__, __FUNCTION__ );
 #        endif // GAMER_DEBUG
 
-         const real EnergyShift = AuxArray_Flt[NUC_AUX_ESHIFT    ];
-         const real Dens2CGS    = AuxArray_Flt[NUC_AUX_DENS2CGS  ];
-         const real Kelvin2MeV  = AuxArray_Flt[NUC_AUX_KELVIN2MEV];
-         const real sEint2Code  = AuxArray_Flt[NUC_AUX_VSQR2CODE ];
-
-         const int  NRho        = AuxArray_Int[NUC_AUX_NRHO ];
-         const int  NEps        = AuxArray_Int[NUC_AUX_NEPS ];
-         const int  NYe         = AuxArray_Int[NUC_AUX_NYE  ];
-         const int  NMode       = AuxArray_Int[NUC_AUX_NMODE];
 
          real Dens_CGS  = Dens_Code * Dens2CGS;
          real Temp_MeV  = Temp_Kelv * Kelvin2MeV;
@@ -586,20 +588,19 @@ static void EoS_General_Nuclear( const int Mode, real Out[], const real In[], co
          real Useless   = NULL_REAL;
          int  Err       = NULL_INT;
 
-
 //       check floating-point overflow and Ye
 #        ifdef GAMER_DEBUG
          if ( Nuc_Overflow(Dens_CGS) )
-            printf( "ERROR : EoS overflow (Dens_CGS %13.7e, Dens_Code %13.7e, Dens2CGS %13.7e) in %s() !!\n",
-                    Dens_CGS, Dens_Code, Dens2CGS, __FUNCTION__ );
+            printf( "ERROR : EoS overflow (Dens_CGS %13.7e, Dens_Code %13.7e, Dens2CGS %13.7e, Mode %d) in %s() !!\n",
+                    Dens_CGS, Dens_Code, Dens2CGS, Mode, __FUNCTION__ );
 
          if ( Nuc_Overflow(Temp_MeV) )
-            printf( "ERROR : EoS overflow (Temp_MeV %13.7e, Temp_Kelv %13.7e, Kelvin2MeV %13.7e) in %s() !!\n",
-                    Temp_MeV, Temp_Kelv, Kelvin2MeV, __FUNCTION__ );
+            printf( "ERROR : EoS overflow (Temp_MeV %13.7e, Temp_Kelv %13.7e, Kelvin2MeV %13.7e, Mode %d) in %s() !!\n",
+                    Temp_MeV, Temp_Kelv, Kelvin2MeV, Mode, __FUNCTION__ );
 
          if ( Ye < (real)Table[NUC_TAB_YE][0]  ||  Ye > (real)Table[NUC_TAB_YE][NYe-1] )
-            printf( "ERROR : invalid Ye = %13.7e (min = %13.7e, max = %13.7e) in %s() !!\n",
-                    Ye, Table[NUC_TAB_YE][0], Table[NUC_TAB_YE][NYe-1], __FUNCTION__ );
+            printf( "ERROR : invalid Ye = %13.7e (min = %13.7e, max = %13.7e, Mode %d) in %s() !!\n",
+                    Ye, Table[NUC_TAB_YE][0], Table[NUC_TAB_YE][NYe-1], Mode, __FUNCTION__ );
 #        endif // GAMER_DEBUG
 
 
@@ -629,15 +630,15 @@ static void EoS_General_Nuclear( const int Mode, real Out[], const real In[], co
 //       still require Eint>0 for the nuclear EoS
          if ( Hydro_CheckNegative(Eint_Code) )
          {
-            printf( "ERROR : invalid output internal energy density (%13.7e) in %s() !!\n", Eint_Code, __FUNCTION__ );
-            printf( "        Dens=%13.7e, Temp=%13.7e, Ye=%13.7e\n", Dens_Code, Temp_Kelv, Ye );
+            printf( "ERROR : invalid output internal energy density (%13.7e code units) in %s() !!\n", Eint_Code, __FUNCTION__ );
+            printf( "        Dens=%13.7e code units, Temp=%13.7e K, Ye=%13.7e, Mode %d\n", Dens_Code, Temp_Kelv, Ye, Mode );
             printf( "        EoS error code: %d\n", Err );
          }
 
          if ( Hydro_CheckNegative(Entr) )
          {
-            printf( "ERROR : invalid output entropy (%13.7e) in %s() !!\n", Entr, __FUNCTION__ );
-            printf( "        Dens=%13.7e, Temp=%13.7e, Ye=%13.7e\n", Dens_Code, Temp_Kelv, Ye );
+            printf( "ERROR : invalid output entropy (%13.7e code units) in %s() !!\n", Entr, __FUNCTION__ );
+            printf( "        Dens=%13.7e code units, Temp=%13.7e K, Ye=%13.7e, Mode %d\n", Dens_Code, Temp_Kelv, Ye, Mode );
             printf( "        EoS error code: %d\n", Err );
          }
 #        endif // GAMER_DEBUG
@@ -667,30 +668,21 @@ static void EoS_General_Nuclear( const int Mode, real Out[], const real In[], co
                     Ye, __FILE__, __LINE__, __FUNCTION__ );
 #        endif // GAMER_DEBUG
 
-         const real EnergyShift = AuxArray_Flt[NUC_AUX_ESHIFT   ];
-         const real Dens2CGS    = AuxArray_Flt[NUC_AUX_DENS2CGS ];
-         const real sEint2Code  = AuxArray_Flt[NUC_AUX_VSQR2CODE];
-
-         const int  NRho        = AuxArray_Int[NUC_AUX_NRHO ];
-         const int  NEps        = AuxArray_Int[NUC_AUX_NEPS ];
-         const int  NYe         = AuxArray_Int[NUC_AUX_NYE  ];
-         const int  NMode       = AuxArray_Int[NUC_AUX_NMODE];
 
          real Dens_CGS  = Dens_Code * Dens2CGS;
          real sEint_CGS = NULL_REAL;
          real Useless   = NULL_REAL;
          int  Err       = NULL_INT;
 
-
 //       check floating-point overflow and Ye
 #        ifdef GAMER_DEBUG
          if ( Nuc_Overflow(Dens_CGS) )
-            printf( "ERROR : EoS overflow (Dens_CGS %13.7e, Dens_Code %13.7e, Dens2CGS %13.7e) in %s() !!\n",
-                    Dens_CGS, Dens_Code, Dens2CGS, __FUNCTION__ );
+            printf( "ERROR : EoS overflow (Dens_CGS %13.7e, Dens_Code %13.7e, Dens2CGS %13.7e, Mode %d) in %s() !!\n",
+                    Dens_CGS, Dens_Code, Dens2CGS, Mode, __FUNCTION__ );
 
          if ( Ye < (real)Table[NUC_TAB_YE][0]  ||  Ye > (real)Table[NUC_TAB_YE][NYe-1] )
-            printf( "ERROR : invalid Ye = %13.7e (min = %13.7e, max = %13.7e) in %s() !!\n",
-                    Ye, Table[NUC_TAB_YE][0], Table[NUC_TAB_YE][NYe-1], __FUNCTION__ );
+            printf( "ERROR : invalid Ye = %13.7e (min = %13.7e, max = %13.7e, Mode %d) in %s() !!\n",
+                    Ye, Table[NUC_TAB_YE][0], Table[NUC_TAB_YE][NYe-1], Mode, __FUNCTION__ );
 #        endif // GAMER_DEBUG
 
 
@@ -715,8 +707,8 @@ static void EoS_General_Nuclear( const int Mode, real Out[], const real In[], co
 //       still require Eint>0 for the nuclear EoS
          if ( Hydro_CheckNegative(Eint_Code) )
          {
-            printf( "ERROR : invalid output internal energy density (%13.7e) in %s() !!\n", Eint_Code, __FUNCTION__ );
-            printf( "        Dens=%13.7e, Entr=%13.7e, Ye=%13.7e\n", Dens_Code, Entr, Ye );
+            printf( "ERROR : invalid output internal energy density (%13.7e code units) in %s() !!\n", Eint_Code, __FUNCTION__ );
+            printf( "        Dens=%13.7e code units, Entr=%13.7e kB/baryon, Ye=%13.7e, Mode %d\n", Dens_Code, Entr, Ye, Mode );
             printf( "        EoS error code: %d\n", Err );
          }
 #        endif // GAMER_DEBUG

--- a/src/EoS/Nuclear/CPU_EoS_Nuclear.cpp
+++ b/src/EoS/Nuclear/CPU_EoS_Nuclear.cpp
@@ -55,7 +55,7 @@ void CUAPI_PassNuclearEoSTable2GPU();
 
 3. Three steps are required to implement an EoS
 
-   I.   Set an EoS auxiliary array
+   I.   Set EoS auxiliary arrays
    II.  Implement EoS conversion functions
    III. Set EoS initialization functions
 
@@ -70,7 +70,7 @@ void CUAPI_PassNuclearEoSTable2GPU();
 
 
 // =============================================
-// I. Set an EoS auxiliary array
+// I. Set EoS auxiliary arrays
 // =============================================
 
 //-------------------------------------------------------------------------------------------------------
@@ -89,17 +89,19 @@ void CUAPI_PassNuclearEoSTable2GPU();
 void EoS_SetAuxArray_Nuclear( double AuxArray_Flt[], int AuxArray_Int[] )
 {
 
-   AuxArray_Flt[NUC_AUX_ESHIFT   ] = g_energy_shift;
-   AuxArray_Flt[NUC_AUX_DENS2CGS ] = UNIT_D;
-   AuxArray_Flt[NUC_AUX_PRES2CGS ] = UNIT_P;
-   AuxArray_Flt[NUC_AUX_VSQR2CGS ] = SQR( UNIT_V );
-   AuxArray_Flt[NUC_AUX_PRES2CODE] = 1.0 / UNIT_P;
-   AuxArray_Flt[NUC_AUX_VSQR2CODE] = 1.0 / SQR(UNIT_V);
+   AuxArray_Flt[NUC_AUX_ESHIFT    ] = g_energy_shift;
+   AuxArray_Flt[NUC_AUX_DENS2CGS  ] = UNIT_D;
+   AuxArray_Flt[NUC_AUX_PRES2CGS  ] = UNIT_P;
+   AuxArray_Flt[NUC_AUX_VSQR2CGS  ] = SQR( UNIT_V );
+   AuxArray_Flt[NUC_AUX_PRES2CODE ] = 1.0 / UNIT_P;
+   AuxArray_Flt[NUC_AUX_VSQR2CODE ] = 1.0 / SQR(UNIT_V);
+   AuxArray_Flt[NUC_AUX_KELVIN2MEV] = Const_kB_eV*1.0e-6;
+   AuxArray_Flt[NUC_AUX_MEV2KELVIN] = 1.0 / AuxArray_Flt[NUC_AUX_KELVIN2MEV];
 
-   AuxArray_Int[NUC_AUX_NRHO     ] = g_nrho;
-   AuxArray_Int[NUC_AUX_NEPS     ] = g_neps;
-   AuxArray_Int[NUC_AUX_NYE      ] = g_nye;
-   AuxArray_Int[NUC_AUX_NMODE    ] = g_nmode;
+   AuxArray_Int[NUC_AUX_NRHO      ] = g_nrho;
+   AuxArray_Int[NUC_AUX_NEPS      ] = g_neps;
+   AuxArray_Int[NUC_AUX_NYE       ] = g_nye;
+   AuxArray_Int[NUC_AUX_NMODE     ] = g_nmode;
 
 } // FUNCTION : EoS_SetAuxArray_Nuclear
 #endif // #ifndef __CUDACC__
@@ -111,6 +113,7 @@ void EoS_SetAuxArray_Nuclear( double AuxArray_Flt[], int AuxArray_Int[] )
 //     (1) EoS_DensEint2Pres_*
 //     (2) EoS_DensPres2Eint_*
 //     (3) EoS_DensPres2CSqr_*
+//     (4) EoS_General_*
 // =============================================
 
 #ifdef GAMER_DEBUG
@@ -183,10 +186,10 @@ static real EoS_DensEint2Pres_Nuclear( const real Dens_Code, const real Eint_Cod
    const real sEint2CGS   = AuxArray_Flt[NUC_AUX_VSQR2CGS ];
    const real Pres2Code   = AuxArray_Flt[NUC_AUX_PRES2CODE];
 
-   const int  NRho        = AuxArray_Int[NUC_AUX_NRHO  ];
-   const int  NEps        = AuxArray_Int[NUC_AUX_NEPS  ];
-   const int  NYe         = AuxArray_Int[NUC_AUX_NYE   ];
-   const int  NMode       = AuxArray_Int[NUC_AUX_NMODE ];
+   const int  NRho        = AuxArray_Int[NUC_AUX_NRHO ];
+   const int  NEps        = AuxArray_Int[NUC_AUX_NEPS ];
+   const int  NYe         = AuxArray_Int[NUC_AUX_NYE  ];
+   const int  NMode       = AuxArray_Int[NUC_AUX_NMODE];
 
    int  Mode      = NUC_MODE_ENGY;
    real Dens_CGS  = Dens_Code * Dens2CGS;
@@ -236,8 +239,8 @@ static real EoS_DensEint2Pres_Nuclear( const real Dens_Code, const real Eint_Cod
       printf( "        Passive scalars:" );
       for (int v=0; v<NCOMP_PASSIVE; v++)    printf( " %d=%13.7e", v, Passive_Code[v] );
       printf( "\n" );
-      printf( "        EoS error code: %d\n", Err );
 #     endif
+      printf( "        EoS error code: %d\n", Err );
    }
 #  endif // GAMER_DEBUG
 
@@ -292,10 +295,10 @@ static real EoS_DensPres2Eint_Nuclear( const real Dens_Code, const real Pres_Cod
    const real Pres2CGS    = AuxArray_Flt[NUC_AUX_PRES2CGS ];
    const real sEint2Code  = AuxArray_Flt[NUC_AUX_VSQR2CODE];
 
-   const int  NRho        = AuxArray_Int[NUC_AUX_NRHO  ];
-   const int  NEps        = AuxArray_Int[NUC_AUX_NEPS  ];
-   const int  NYe         = AuxArray_Int[NUC_AUX_NYE   ];
-   const int  NMode       = AuxArray_Int[NUC_AUX_NMODE ];
+   const int  NRho        = AuxArray_Int[NUC_AUX_NRHO ];
+   const int  NEps        = AuxArray_Int[NUC_AUX_NEPS ];
+   const int  NYe         = AuxArray_Int[NUC_AUX_NYE  ];
+   const int  NMode       = AuxArray_Int[NUC_AUX_NMODE];
 
    int  Mode      = NUC_MODE_PRES;
    real Dens_CGS  = Dens_Code * Dens2CGS;
@@ -346,8 +349,8 @@ static real EoS_DensPres2Eint_Nuclear( const real Dens_Code, const real Pres_Cod
       printf( "        Passive scalars:" );
       for (int v=0; v<NCOMP_PASSIVE; v++)    printf( " %d=%13.7e", v, Passive_Code[v] );
       printf( "\n" );
-      printf( "        EoS error code: %d\n", Err );
 #     endif
+      printf( "        EoS error code: %d\n", Err );
    }
 #  endif // GAMER_DEBUG
 
@@ -401,10 +404,10 @@ static real EoS_DensPres2CSqr_Nuclear( const real Dens_Code, const real Pres_Cod
    const real Pres2CGS    = AuxArray_Flt[NUC_AUX_PRES2CGS ];
    const real CsSqr2Code  = AuxArray_Flt[NUC_AUX_VSQR2CODE];
 
-   const int  NRho        = AuxArray_Int[NUC_AUX_NRHO  ];
-   const int  NEps        = AuxArray_Int[NUC_AUX_NEPS  ];
-   const int  NYe         = AuxArray_Int[NUC_AUX_NYE   ];
-   const int  NMode       = AuxArray_Int[NUC_AUX_NMODE ];
+   const int  NRho        = AuxArray_Int[NUC_AUX_NRHO ];
+   const int  NEps        = AuxArray_Int[NUC_AUX_NEPS ];
+   const int  NYe         = AuxArray_Int[NUC_AUX_NYE  ];
+   const int  NMode       = AuxArray_Int[NUC_AUX_NMODE];
 
    int  Mode     = NUC_MODE_PRES;
    real Dens_CGS = Dens_Code * Dens2CGS;
@@ -454,8 +457,8 @@ static real EoS_DensPres2CSqr_Nuclear( const real Dens_Code, const real Pres_Cod
       printf( "        Passive scalars:" );
       for (int v=0; v<NCOMP_PASSIVE; v++)    printf( " %d=%13.7e", v, Passive_Code[v] );
       printf( "\n" );
-      printf( "        EoS error code: %d\n", Err );
 #     endif
+      printf( "        EoS error code: %d\n", Err );
    }
 #  endif // GAMER_DEBUG
 
@@ -463,6 +466,245 @@ static real EoS_DensPres2CSqr_Nuclear( const real Dens_Code, const real Pres_Cod
    return Cs2_Code;
 
 } // FUNCTION : EoS_DensPres2CSqr_Nuclear
+
+
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  EoS_General_Nuclear
+// Description :  General EoS converter: In[] -> Out[]
+//
+// Note        :  1. See EoS_DensEint2Pres_Nuclear()
+//                2. In[] and Out[] must NOT overlap
+//                3. Support the temperature and entropy modes:
+//                   (1) Temperature mode:
+//                         In [0] = mass density in code units
+//                         In [1] = temperature in kelvin
+//                         In [2] = Ye
+//                         Out[0] = volume energy density in code units (with energy shift)
+//                         Out[1] = entropy in kB/baryon
+//                   (2) Entropy mode:
+//                         In [0] = mass density in code units
+//                         In [1] = entropy in kB/baryon
+//                         In [2] = Ye
+//                         Out[0] = volume energy density in code units (with energy shift)
+//                   --> Both In[] and Out[] can be extended if necessary
+//                4. No units conversion will be applied to entropy and Ye
+//
+// Parameter   :  Mode       : NUC_MODE_TEMP or NUC_MODE_ENTR
+//                Out        : Output array     (see the Note above)
+//                In         : Input array      (see the Note above)
+//                AuxArray_* : Auxiliary arrays (see the Note above)
+//                Table      : EoS tables
+//
+// Return      :  Out[]
+//-------------------------------------------------------------------------------------------------------
+GPU_DEVICE_NOINLINE
+static void EoS_General_Nuclear( const int Mode, real Out[], const real In[], const double AuxArray_Flt[],
+                                 const int AuxArray_Int[], const real *const Table[EOS_NTABLE_MAX] )
+{
+
+// general check
+#  ifdef GAMER_DEBUG
+   if ( Out          == NULL )   printf( "ERROR : Out == NULL in %s !!\n", __FUNCTION__ );
+   if ( In           == NULL )   printf( "ERROR : In == NULL in %s !!\n", __FUNCTION__ );
+   if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
+   if ( AuxArray_Int == NULL )   printf( "ERROR : AuxArray_Int == NULL in %s !!\n", __FUNCTION__ );
+#  endif // GAMER_DEBUG
+
+
+   switch ( Mode )
+   {
+//    temperature mode
+      case NUC_MODE_TEMP :
+      {
+         const real Dens_Code = In[0];
+         const real Temp_Kelv = In[1];
+         const real Ye        = In[2];
+
+//       check
+#        ifdef GAMER_DEBUG
+         if ( Hydro_CheckNegative(Dens_Code) )
+            printf( "ERROR : invalid input density (%14.7e) at file <%s>, line <%d>, function <%s>\n",
+                    Dens_Code, __FILE__, __LINE__, __FUNCTION__ );
+
+         if ( Hydro_CheckNegative(Temp_Kelv) )
+            printf( "ERROR : invalid input temperature (%14.7e) at file <%s>, line <%d>, function <%s>\n",
+                    Temp_Kelv, __FILE__, __LINE__, __FUNCTION__ );
+
+         if ( Hydro_CheckNegative(Ye) )
+            printf( "ERROR : invalid input Ye (%14.7e) at file <%s>, line <%d>, function <%s>\n",
+                    Ye, __FILE__, __LINE__, __FUNCTION__ );
+#        endif // GAMER_DEBUG
+
+         const real EnergyShift = AuxArray_Flt[NUC_AUX_ESHIFT    ];
+         const real Dens2CGS    = AuxArray_Flt[NUC_AUX_DENS2CGS  ];
+         const real Kelvin2MeV  = AuxArray_Flt[NUC_AUX_KELVIN2MEV];
+         const real sEint2Code  = AuxArray_Flt[NUC_AUX_VSQR2CODE ];
+
+         const int  NRho        = AuxArray_Int[NUC_AUX_NRHO ];
+         const int  NEps        = AuxArray_Int[NUC_AUX_NEPS ];
+         const int  NYe         = AuxArray_Int[NUC_AUX_NYE  ];
+         const int  NMode       = AuxArray_Int[NUC_AUX_NMODE];
+
+         real Dens_CGS  = Dens_Code * Dens2CGS;
+         real Temp_MeV  = Temp_Kelv * Kelvin2MeV;
+         real sEint_CGS = NULL_REAL;
+         real Entr      = NULL_REAL;
+         real Useless   = NULL_REAL;
+         int  Err       = NULL_INT;
+
+
+//       check floating-point overflow and Ye
+#        ifdef GAMER_DEBUG
+         if ( Nuc_Overflow(Dens_CGS) )
+            printf( "ERROR : EoS overflow (Dens_CGS %13.7e, Dens_Code %13.7e, Dens2CGS %13.7e) in %s() !!\n",
+                    Dens_CGS, Dens_Code, Dens2CGS, __FUNCTION__ );
+
+         if ( Nuc_Overflow(Temp_MeV) )
+            printf( "ERROR : EoS overflow (Temp_MeV %13.7e, Temp_Kelv %13.7e, Kelvin2MeV %13.7e) in %s() !!\n",
+                    Temp_MeV, Temp_Kelv, Kelvin2MeV, __FUNCTION__ );
+
+         if ( Ye < (real)Table[NUC_TAB_YE][0]  ||  Ye > (real)Table[NUC_TAB_YE][NYe-1] )
+            printf( "ERROR : invalid Ye = %13.7e (min = %13.7e, max = %13.7e) in %s() !!\n",
+                    Ye, Table[NUC_TAB_YE][0], Table[NUC_TAB_YE][NYe-1], __FUNCTION__ );
+#        endif // GAMER_DEBUG
+
+
+//       invoke the nuclear EoS driver
+         nuc_eos_C_short( Dens_CGS, &sEint_CGS, Ye, &Temp_MeV, &Entr, &Useless, &Useless, &Useless,
+                          EnergyShift, NRho, NEps, NYe, NMode,
+                          Table[NUC_TAB_ALL], Table[NUC_TAB_ALL_MODE], Table[NUC_TAB_RHO], Table[NUC_TAB_EPS],
+                          Table[NUC_TAB_YE], Table[NUC_TAB_TEMP_MODE], Table[NUC_TAB_ENTR_MODE], Table[NUC_TAB_PRES_MODE],
+                          Mode, &Err, NULL_REAL );
+
+//       trigger a *hard failure* if the EoS driver fails
+         if ( Err )
+         {
+            sEint_CGS = NAN;
+            Entr      = NAN;
+         }
+
+
+//       store the output results
+         const real Eint_Code = (  ( sEint_CGS + EnergyShift ) * sEint2Code  ) * Dens_Code;
+         Out[0] = Eint_Code;  // volume energy density in code units (with energy shift)
+         Out[1] = Entr;       // entropy in kB/baryon
+
+
+//       final check
+#        ifdef GAMER_DEBUG
+//       still require Eint>0 for the nuclear EoS
+         if ( Hydro_CheckNegative(Eint_Code) )
+         {
+            printf( "ERROR : invalid output internal energy density (%13.7e) in %s() !!\n", Eint_Code, __FUNCTION__ );
+            printf( "        Dens=%13.7e, Temp=%13.7e, Ye=%13.7e\n", Dens_Code, Temp_Kelv, Ye );
+            printf( "        EoS error code: %d\n", Err );
+         }
+
+         if ( Hydro_CheckNegative(Entr) )
+         {
+            printf( "ERROR : invalid output entropy (%13.7e) in %s() !!\n", Entr, __FUNCTION__ );
+            printf( "        Dens=%13.7e, Temp=%13.7e, Ye=%13.7e\n", Dens_Code, Temp_Kelv, Ye );
+            printf( "        EoS error code: %d\n", Err );
+         }
+#        endif // GAMER_DEBUG
+      } // case NUC_MODE_TEMP
+      break;
+
+
+//    entropy mode
+      case NUC_MODE_ENTR :
+      {
+         const real Dens_Code = In[0];
+               real Entr      = In[1];
+         const real Ye        = In[2];
+
+//       check
+#        ifdef GAMER_DEBUG
+         if ( Hydro_CheckNegative(Dens_Code) )
+            printf( "ERROR : invalid input density (%14.7e) at file <%s>, line <%d>, function <%s>\n",
+                    Dens_Code, __FILE__, __LINE__, __FUNCTION__ );
+
+         if ( Hydro_CheckNegative(Entr) )
+            printf( "ERROR : invalid input entropy (%14.7e) at file <%s>, line <%d>, function <%s>\n",
+                    Entr, __FILE__, __LINE__, __FUNCTION__ );
+
+         if ( Hydro_CheckNegative(Ye) )
+            printf( "ERROR : invalid input Ye (%14.7e) at file <%s>, line <%d>, function <%s>\n",
+                    Ye, __FILE__, __LINE__, __FUNCTION__ );
+#        endif // GAMER_DEBUG
+
+         const real EnergyShift = AuxArray_Flt[NUC_AUX_ESHIFT   ];
+         const real Dens2CGS    = AuxArray_Flt[NUC_AUX_DENS2CGS ];
+         const real sEint2Code  = AuxArray_Flt[NUC_AUX_VSQR2CODE];
+
+         const int  NRho        = AuxArray_Int[NUC_AUX_NRHO ];
+         const int  NEps        = AuxArray_Int[NUC_AUX_NEPS ];
+         const int  NYe         = AuxArray_Int[NUC_AUX_NYE  ];
+         const int  NMode       = AuxArray_Int[NUC_AUX_NMODE];
+
+         real Dens_CGS  = Dens_Code * Dens2CGS;
+         real sEint_CGS = NULL_REAL;
+         real Useless   = NULL_REAL;
+         int  Err       = NULL_INT;
+
+
+//       check floating-point overflow and Ye
+#        ifdef GAMER_DEBUG
+         if ( Nuc_Overflow(Dens_CGS) )
+            printf( "ERROR : EoS overflow (Dens_CGS %13.7e, Dens_Code %13.7e, Dens2CGS %13.7e) in %s() !!\n",
+                    Dens_CGS, Dens_Code, Dens2CGS, __FUNCTION__ );
+
+         if ( Ye < (real)Table[NUC_TAB_YE][0]  ||  Ye > (real)Table[NUC_TAB_YE][NYe-1] )
+            printf( "ERROR : invalid Ye = %13.7e (min = %13.7e, max = %13.7e) in %s() !!\n",
+                    Ye, Table[NUC_TAB_YE][0], Table[NUC_TAB_YE][NYe-1], __FUNCTION__ );
+#        endif // GAMER_DEBUG
+
+
+//       invoke the nuclear EoS driver
+         nuc_eos_C_short( Dens_CGS, &sEint_CGS, Ye, &Useless, &Entr, &Useless, &Useless, &Useless,
+                          EnergyShift, NRho, NEps, NYe, NMode,
+                          Table[NUC_TAB_ALL], Table[NUC_TAB_ALL_MODE], Table[NUC_TAB_RHO], Table[NUC_TAB_EPS],
+                          Table[NUC_TAB_YE], Table[NUC_TAB_TEMP_MODE], Table[NUC_TAB_ENTR_MODE], Table[NUC_TAB_PRES_MODE],
+                          Mode, &Err, NULL_REAL );
+
+//       trigger a *hard failure* if the EoS driver fails
+         if ( Err )  sEint_CGS = NAN;
+
+
+//       store the output results
+         const real Eint_Code = (  ( sEint_CGS + EnergyShift ) * sEint2Code  ) * Dens_Code;
+         Out[0] = Eint_Code;  // volume energy density in code units (with energy shift)
+
+
+//       final check
+#        ifdef GAMER_DEBUG
+//       still require Eint>0 for the nuclear EoS
+         if ( Hydro_CheckNegative(Eint_Code) )
+         {
+            printf( "ERROR : invalid output internal energy density (%13.7e) in %s() !!\n", Eint_Code, __FUNCTION__ );
+            printf( "        Dens=%13.7e, Entr=%13.7e, Ye=%13.7e\n", Dens_Code, Entr, Ye );
+            printf( "        EoS error code: %d\n", Err );
+         }
+#        endif // GAMER_DEBUG
+      } // case NUC_MODE_ENTR
+      break;
+
+
+      default :
+      {
+#        ifdef GAMER_DEBUG
+         printf( "ERROR : unsupported mode (%d) at file <%s>, line <%d>, function <%s>\n",
+                 Mode, __FILE__, __LINE__, __FUNCTION__ );
+#        endif
+
+//       trigger a *hard failure* here
+         Out[0] = NAN;
+      } // default
+
+   } // switch ( Mode )
+
+} // FUNCTION : EoS_General_Nuclear
 
 
 
@@ -479,6 +721,7 @@ static real EoS_DensPres2CSqr_Nuclear( const real Dens_Code, const real Pres_Cod
 FUNC_SPACE EoS_DE2P_t EoS_DensEint2Pres_Ptr = EoS_DensEint2Pres_Nuclear;
 FUNC_SPACE EoS_DP2E_t EoS_DensPres2Eint_Ptr = EoS_DensPres2Eint_Nuclear;
 FUNC_SPACE EoS_DP2C_t EoS_DensPres2CSqr_Ptr = EoS_DensPres2CSqr_Nuclear;
+FUNC_SPACE EoS_GENE_t EoS_General_Ptr       = EoS_General_Nuclear;
 
 //-----------------------------------------------------------------------------------------
 // Function    :  EoS_SetCPU/GPUFunc_Nuclear
@@ -496,29 +739,35 @@ FUNC_SPACE EoS_DP2C_t EoS_DensPres2CSqr_Ptr = EoS_DensPres2CSqr_Nuclear;
 // Parameter   :  EoS_DensEint2Pres_CPU/GPUPtr : CPU/GPU function pointers to be set
 //                EoS_DensPres2Eint_CPU/GPUPtr : ...
 //                EoS_DensPres2CSqr_CPU/GPUPtr : ...
+//                EoS_General_CPU/GPUPtr       : ...
 //
-// Return      :  EoS_DensEint2Pres_CPU, EoS_DensPres2Eint_CPU/GPUPtr, EoS_DensPres2CSqr_CPU/GPUPtr
+// Return      :  EoS_DensEint2Pres_CPU/GPUPtr, EoS_DensPres2Eint_CPU/GPUPtr,
+//                EoS_DensPres2CSqr_CPU/GPUPtr, EoS_General_CPU/GPUPtr
 //-----------------------------------------------------------------------------------------
 #ifdef __CUDACC__
 __host__
 void EoS_SetGPUFunc_Nuclear( EoS_DE2P_t &EoS_DensEint2Pres_GPUPtr,
                              EoS_DP2E_t &EoS_DensPres2Eint_GPUPtr,
-                             EoS_DP2C_t &EoS_DensPres2CSqr_GPUPtr )
+                             EoS_DP2C_t &EoS_DensPres2CSqr_GPUPtr,
+                             EoS_GENE_t &EoS_General_GPUPtr )
 {
    CUDA_CHECK_ERROR(  cudaMemcpyFromSymbol( &EoS_DensEint2Pres_GPUPtr, EoS_DensEint2Pres_Ptr, sizeof(EoS_DE2P_t) )  );
    CUDA_CHECK_ERROR(  cudaMemcpyFromSymbol( &EoS_DensPres2Eint_GPUPtr, EoS_DensPres2Eint_Ptr, sizeof(EoS_DP2E_t) )  );
    CUDA_CHECK_ERROR(  cudaMemcpyFromSymbol( &EoS_DensPres2CSqr_GPUPtr, EoS_DensPres2CSqr_Ptr, sizeof(EoS_DP2C_t) )  );
+   CUDA_CHECK_ERROR(  cudaMemcpyFromSymbol( &EoS_General_GPUPtr,       EoS_General_Ptr,       sizeof(EoS_GENE_t) )  );
 }
 
 #else // #ifdef __CUDACC__
 
 void EoS_SetCPUFunc_Nuclear( EoS_DE2P_t &EoS_DensEint2Pres_CPUPtr,
                              EoS_DP2E_t &EoS_DensPres2Eint_CPUPtr,
-                             EoS_DP2C_t &EoS_DensPres2CSqr_CPUPtr )
+                             EoS_DP2C_t &EoS_DensPres2CSqr_CPUPtr,
+                             EoS_GENE_t &EoS_General_CPUPtr )
 {
    EoS_DensEint2Pres_CPUPtr = EoS_DensEint2Pres_Ptr;
    EoS_DensPres2Eint_CPUPtr = EoS_DensPres2Eint_Ptr;
    EoS_DensPres2CSqr_CPUPtr = EoS_DensPres2CSqr_Ptr;
+   EoS_General_CPUPtr       = EoS_General_Ptr;
 }
 
 #endif // #ifdef __CUDACC__ ... else ...
@@ -529,16 +778,16 @@ void EoS_SetCPUFunc_Nuclear( EoS_DE2P_t &EoS_DensEint2Pres_CPUPtr,
 
 // local function prototypes
 void EoS_SetAuxArray_Nuclear( double [], int [] );
-void EoS_SetCPUFunc_Nuclear( EoS_DE2P_t &, EoS_DP2E_t &, EoS_DP2C_t & );
+void EoS_SetCPUFunc_Nuclear( EoS_DE2P_t &, EoS_DP2E_t &, EoS_DP2C_t &, EoS_GENE_t & );
 #ifdef GPU
-void EoS_SetGPUFunc_Nuclear( EoS_DE2P_t &, EoS_DP2E_t &, EoS_DP2C_t & );
+void EoS_SetGPUFunc_Nuclear( EoS_DE2P_t &, EoS_DP2E_t &, EoS_DP2C_t &, EoS_GENE_t & );
 #endif
 
 //-----------------------------------------------------------------------------------------
 // Function    :  EoS_Init_Nuclear
 // Description :  Initialize EoS
 //
-// Note        :  1. Set an auxiliary array by invoking EoS_SetAuxArray_*()
+// Note        :  1. Set auxiliary arrays by invoking EoS_SetAuxArray_*()
 //                   --> It will be copied to GPU automatically in CUAPI_SetConstMemory()
 //                2. Set the CPU/GPU EoS routines by invoking EoS_SetCPU/GPUFunc_*()
 //                3. Invoked by EoS_Init()
@@ -561,9 +810,11 @@ void EoS_Init_Nuclear()
    nuc_eos_C_ReadTable( NUC_TABLE );
 
    EoS_SetAuxArray_Nuclear( EoS_AuxArray_Flt, EoS_AuxArray_Int );
-   EoS_SetCPUFunc_Nuclear( EoS_DensEint2Pres_CPUPtr, EoS_DensPres2Eint_CPUPtr, EoS_DensPres2CSqr_CPUPtr );
+   EoS_SetCPUFunc_Nuclear( EoS_DensEint2Pres_CPUPtr, EoS_DensPres2Eint_CPUPtr,
+                           EoS_DensPres2CSqr_CPUPtr, EoS_General_CPUPtr );
 #  ifdef GPU
-   EoS_SetGPUFunc_Nuclear( EoS_DensEint2Pres_GPUPtr, EoS_DensPres2Eint_GPUPtr, EoS_DensPres2CSqr_GPUPtr );
+   EoS_SetGPUFunc_Nuclear( EoS_DensEint2Pres_GPUPtr, EoS_DensPres2Eint_GPUPtr,
+                           EoS_DensPres2CSqr_GPUPtr, EoS_General_GPUPtr );
 #  endif
 
 #  ifdef GPU

--- a/src/EoS/Nuclear/NuclearEoS.h
+++ b/src/EoS/Nuclear/NuclearEoS.h
@@ -17,6 +17,8 @@
 #define NUC_AUX_VSQR2CGS      3     // AuxArray_Flt: convert velocity^2 to cgs
 #define NUC_AUX_PRES2CODE     4     // AuxArray_Flt: convert pressure   to code unit
 #define NUC_AUX_VSQR2CODE     5     // AuxArray_Flt: convert velocity^2 to code unit
+#define NUC_AUX_KELVIN2MEV    6     // AuxArray_Flt: convert kelvin     to MeV
+#define NUC_AUX_MEV2KELVIN    7     // AuxArray_Flt: convert MeV        to kelvin
 
 #define NUC_AUX_NRHO          0     // AuxArray_Int: nrho
 #define NUC_AUX_NEPS          1     // AuxArray_Int: neps

--- a/src/EoS/User_Template/CPU_EoS_User_Template.cpp
+++ b/src/EoS/User_Template/CPU_EoS_User_Template.cpp
@@ -84,12 +84,15 @@ void EoS_SetAuxArray_User_Template( double AuxArray_Flt[], int AuxArray_Int[] )
 //                Passive    : Passive scalars
 //                AuxArray_* : Auxiliary arrays (see the Note above)
 //                Table      : EoS tables
+//                ExtraInOut : Array to store extra input and output variables if required
+//                             --> Optional and only used when it is not NULL
 //
 // Return      :  Gas pressure
 //-------------------------------------------------------------------------------------------------------
 GPU_DEVICE_NOINLINE
-static real EoS_DensEint2Pres_User_Template( const real Dens, const real Eint, const real Passive[], const double AuxArray_Flt[],
-                                             const int AuxArray_Int[], const real *const Table[EOS_NTABLE_MAX] )
+static real EoS_DensEint2Pres_User_Template( const real Dens, const real Eint, const real Passive[],
+                                             const double AuxArray_Flt[], const int AuxArray_Int[],
+                                             const real *const Table[EOS_NTABLE_MAX], real ExtraInOut[] )
 {
 
 // check
@@ -133,6 +136,15 @@ static real EoS_DensEint2Pres_User_Template( const real Dens, const real Eint, c
 #  endif // GAMER_DEBUG
 
 
+// store extra output variables if required
+   /*
+   if ( ExtraInOut != NULL )
+   {
+      ExtraInOut[...] = ...;
+   }
+   */
+
+
    return Pres;
 
 } // FUNCTION : EoS_DensEint2Pres_User_Template
@@ -150,12 +162,15 @@ static real EoS_DensEint2Pres_User_Template( const real Dens, const real Eint, c
 //                Passive    : Passive scalars
 //                AuxArray_* : Auxiliary arrays (see the Note above)
 //                Table      : EoS tables
+//                ExtraInOut : Array to store extra input and output variables if required
+//                             --> Optional and only used when it is not NULL
 //
 // Return      :  Gas internal energy density
 //-------------------------------------------------------------------------------------------------------
 GPU_DEVICE_NOINLINE
-static real EoS_DensPres2Eint_User_Template( const real Dens, const real Pres, const real Passive[], const double AuxArray_Flt[],
-                                             const int AuxArray_Int[], const real *const Table[EOS_NTABLE_MAX] )
+static real EoS_DensPres2Eint_User_Template( const real Dens, const real Pres, const real Passive[],
+                                             const double AuxArray_Flt[], const int AuxArray_Int[],
+                                             const real *const Table[EOS_NTABLE_MAX], real ExtraInOut[] )
 {
 
 // check
@@ -199,6 +214,15 @@ static real EoS_DensPres2Eint_User_Template( const real Dens, const real Pres, c
 #  endif // GAMER_DEBUG
 
 
+// store extra output variables if required
+   /*
+   if ( ExtraInOut != NULL )
+   {
+      ExtraInOut[...] = ...;
+   }
+   */
+
+
    return Eint;
 
 } // FUNCTION : EoS_DensPres2Eint_User_Template
@@ -216,12 +240,15 @@ static real EoS_DensPres2Eint_User_Template( const real Dens, const real Pres, c
 //                Passive    : Passive scalars
 //                AuxArray_* : Auxiliary arrays (see the Note above)
 //                Table      : EoS tables
+//                ExtraInOut : Array to store extra input and output variables if required
+//                             --> Optional and only used when it is not NULL
 //
 // Return      :  Sound speed square
 //-------------------------------------------------------------------------------------------------------
 GPU_DEVICE_NOINLINE
-static real EoS_DensPres2CSqr_User_Template( const real Dens, const real Pres, const real Passive[], const double AuxArray_Flt[],
-                                             const int AuxArray_Int[], const real *const Table[EOS_NTABLE_MAX] )
+static real EoS_DensPres2CSqr_User_Template( const real Dens, const real Pres, const real Passive[],
+                                             const double AuxArray_Flt[], const int AuxArray_Int[],
+                                             const real *const Table[EOS_NTABLE_MAX], real ExtraInOut[] )
 {
 
 // check
@@ -262,6 +289,15 @@ static real EoS_DensPres2CSqr_User_Template( const real Dens, const real Pres, c
 #     endif
    }
 #  endif // GAMER_DEBUG
+
+
+// store extra output variables if required
+   /*
+   if ( ExtraInOut != NULL )
+   {
+      ExtraInOut[...] = ...;
+   }
+   */
 
 
    return Cs2;

--- a/src/EoS/User_Template/CPU_EoS_User_Template.cpp
+++ b/src/EoS/User_Template/CPU_EoS_User_Template.cpp
@@ -69,6 +69,7 @@ void EoS_SetAuxArray_User_Template( double AuxArray_Flt[], int AuxArray_Int[] )
 //     (1) EoS_DensEint2Pres_*
 //     (2) EoS_DensPres2Eint_*
 //     (3) EoS_DensPres2CSqr_*
+//     (4) EoS_General_* [OPTIONAL]
 // =============================================
 
 //-------------------------------------------------------------------------------------------------------
@@ -269,6 +270,43 @@ static real EoS_DensPres2CSqr_User_Template( const real Dens, const real Pres, c
 
 
 
+//-------------------------------------------------------------------------------------------------------
+// Function    :  EoS_General_User_Template
+// Description :  General EoS converter: In[] -> Out[]
+//
+// Note        :  1. See EoS_DensEint2Pres_User_Template()
+//                2. In[] and Out[] must NOT overlap
+//
+// Parameter   :  Mode       : To support multiple modes in this general converter
+//                Out        : Output array
+//                In         : Input array
+//                AuxArray_* : Auxiliary arrays (see the Note above)
+//                Table      : EoS tables
+//
+// Return      :  Out[]
+//-------------------------------------------------------------------------------------------------------
+GPU_DEVICE_NOINLINE
+static void EoS_General_User_Template( const int Mode, real Out[], const real In[], const double AuxArray_Flt[],
+                                       const int AuxArray_Int[], const real *const Table[EOS_NTABLE_MAX] )
+{
+
+// check
+#  ifdef GAMER_DEBUG
+   if ( Out          == NULL )   printf( "ERROR : Out == NULL in %s !!\n", __FUNCTION__ );
+   if ( In           == NULL )   printf( "ERROR : In == NULL in %s !!\n", __FUNCTION__ );
+   if ( AuxArray_Flt == NULL )   printf( "ERROR : AuxArray_Flt == NULL in %s !!\n", __FUNCTION__ );
+   if ( AuxArray_Int == NULL )   printf( "ERROR : AuxArray_Int == NULL in %s !!\n", __FUNCTION__ );
+#  endif // GAMER_DEBUG
+
+
+   /*
+   if ( Mode == ... )   Out[...] = ...;
+   */
+
+} // FUNCTION : EoS_General_User_Template
+
+
+
 // =============================================
 // III. Set EoS initialization functions
 // =============================================
@@ -282,6 +320,7 @@ static real EoS_DensPres2CSqr_User_Template( const real Dens, const real Pres, c
 FUNC_SPACE EoS_DE2P_t EoS_DensEint2Pres_Ptr = EoS_DensEint2Pres_User_Template;
 FUNC_SPACE EoS_DP2E_t EoS_DensPres2Eint_Ptr = EoS_DensPres2Eint_User_Template;
 FUNC_SPACE EoS_DP2C_t EoS_DensPres2CSqr_Ptr = EoS_DensPres2CSqr_User_Template;
+FUNC_SPACE EoS_GENE_t EoS_General_Ptr       = EoS_General_User_Template;
 
 //-----------------------------------------------------------------------------------------
 // Function    :  EoS_SetCPU/GPUFunc_User_Template
@@ -299,29 +338,35 @@ FUNC_SPACE EoS_DP2C_t EoS_DensPres2CSqr_Ptr = EoS_DensPres2CSqr_User_Template;
 // Parameter   :  EoS_DensEint2Pres_CPU/GPUPtr : CPU/GPU function pointers to be set
 //                EoS_DensPres2Eint_CPU/GPUPtr : ...
 //                EoS_DensPres2CSqr_CPU/GPUPtr : ...
+//                EoS_General_CPU/GPUPtr       : ...
 //
-// Return      :  EoS_DensEint2Pres_CPU/GPUPtr, EoS_DensPres2Eint_CPU/GPUPtr, EoS_DensPres2CSqr_CPU/GPUPtr
+// Return      :  EoS_DensEint2Pres_CPU/GPUPtr, EoS_DensPres2Eint_CPU/GPUPtr,
+//                EoS_DensPres2CSqr_CPU/GPUPtr, EoS_General_CPU/GPUPtr
 //-----------------------------------------------------------------------------------------
 #ifdef __CUDACC__
 __host__
 void EoS_SetGPUFunc_User_Template( EoS_DE2P_t &EoS_DensEint2Pres_GPUPtr,
                                    EoS_DP2E_t &EoS_DensPres2Eint_GPUPtr,
-                                   EoS_DP2C_t &EoS_DensPres2CSqr_GPUPtr )
+                                   EoS_DP2C_t &EoS_DensPres2CSqr_GPUPtr,
+                                   EoS_GENE_t &EoS_General_GPUPtr )
 {
    CUDA_CHECK_ERROR(  cudaMemcpyFromSymbol( &EoS_DensEint2Pres_GPUPtr, EoS_DensEint2Pres_Ptr, sizeof(EoS_DE2P_t) )  );
    CUDA_CHECK_ERROR(  cudaMemcpyFromSymbol( &EoS_DensPres2Eint_GPUPtr, EoS_DensPres2Eint_Ptr, sizeof(EoS_DP2E_t) )  );
    CUDA_CHECK_ERROR(  cudaMemcpyFromSymbol( &EoS_DensPres2CSqr_GPUPtr, EoS_DensPres2CSqr_Ptr, sizeof(EoS_DP2C_t) )  );
+   CUDA_CHECK_ERROR(  cudaMemcpyFromSymbol( &EoS_General_GPUPtr,       EoS_General_Ptr,       sizeof(EoS_GENE_t) )  );
 }
 
 #else // #ifdef __CUDACC__
 
 void EoS_SetCPUFunc_User_Template( EoS_DE2P_t &EoS_DensEint2Pres_CPUPtr,
                                    EoS_DP2E_t &EoS_DensPres2Eint_CPUPtr,
-                                   EoS_DP2C_t &EoS_DensPres2CSqr_CPUPtr )
+                                   EoS_DP2C_t &EoS_DensPres2CSqr_CPUPtr,
+                                   EoS_GENE_t &EoS_General_CPUPtr )
 {
    EoS_DensEint2Pres_CPUPtr = EoS_DensEint2Pres_Ptr;
    EoS_DensPres2Eint_CPUPtr = EoS_DensPres2Eint_Ptr;
    EoS_DensPres2CSqr_CPUPtr = EoS_DensPres2CSqr_Ptr;
+   EoS_General_CPUPtr       = EoS_General_Ptr;
 }
 
 #endif // #ifdef __CUDACC__ ... else ...
@@ -332,9 +377,9 @@ void EoS_SetCPUFunc_User_Template( EoS_DE2P_t &EoS_DensEint2Pres_CPUPtr,
 
 // local function prototypes
 void EoS_SetAuxArray_User_Template( double [], int [] );
-void EoS_SetCPUFunc_User_Template( EoS_DE2P_t &, EoS_DP2E_t &, EoS_DP2C_t & );
+void EoS_SetCPUFunc_User_Template( EoS_DE2P_t &, EoS_DP2E_t &, EoS_DP2C_t &, EoS_GENE_t & );
 #ifdef GPU
-void EoS_SetGPUFunc_User_Template( EoS_DE2P_t &, EoS_DP2E_t &, EoS_DP2C_t & );
+void EoS_SetGPUFunc_User_Template( EoS_DE2P_t &, EoS_DP2E_t &, EoS_DP2C_t &, EoS_GENE_t & );
 #endif
 
 //-----------------------------------------------------------------------------------------
@@ -356,9 +401,11 @@ void EoS_Init_User_Template()
 {
 
    EoS_SetAuxArray_User_Template( EoS_AuxArray_Flt, EoS_AuxArray_Int );
-   EoS_SetCPUFunc_User_Template( EoS_DensEint2Pres_CPUPtr, EoS_DensPres2Eint_CPUPtr, EoS_DensPres2CSqr_CPUPtr );
+   EoS_SetCPUFunc_User_Template( EoS_DensEint2Pres_CPUPtr, EoS_DensPres2Eint_CPUPtr,
+                                 EoS_DensPres2CSqr_CPUPtr, EoS_General_CPUPtr );
 #  ifdef GPU
-   EoS_SetGPUFunc_User_Template( EoS_DensEint2Pres_GPUPtr, EoS_DensPres2Eint_GPUPtr, EoS_DensPres2CSqr_GPUPtr );
+   EoS_SetGPUFunc_User_Template( EoS_DensEint2Pres_GPUPtr, EoS_DensPres2Eint_GPUPtr,
+                                 EoS_DensPres2CSqr_GPUPtr, EoS_General_GPUPtr );
 #  endif
 
 } // FUNCTION : EoS_Init_User_Template

--- a/src/Fluid/Flu_BoundaryCondition_User.cpp
+++ b/src/Fluid/Flu_BoundaryCondition_User.cpp
@@ -68,7 +68,7 @@ void BC_User_Template( real fluid[], const double x, const double y, const doubl
 #  if ( NCOMP_PASSIVE > 0 )
 // Passive[X] = ...;
 #  endif
-   Eint       = EoS_DensPres2Eint_CPUPtr( Dens, Pres, Passive, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
+   Eint       = EoS_DensPres2Eint_CPUPtr( Dens, Pres, Passive, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table, NULL );
    Etot       = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, Emag0 );
 
    fluid[DENS] = Dens;

--- a/src/Fluid/Flu_FixUp_Flux.cpp
+++ b/src/Fluid/Flu_FixUp_Flux.cpp
@@ -204,7 +204,8 @@ void Flu_FixUp_Flux( const int lv )
                   real Pres;
                   Pres = Hydro_DensEntropy2Pres( ForEint[DENS], ForEint[ENPY], EoS_AuxArray_Flt[1], CheckMinPres_No, NULL_REAL );
 //                DE_ENPY only supports EOS_GAMMA, which does not involve passive scalars
-                  Eint = EoS_DensPres2Eint_CPUPtr( ForEint[DENS], Pres, NULL, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
+                  Eint = EoS_DensPres2Eint_CPUPtr( ForEint[DENS], Pres, NULL, EoS_AuxArray_Flt, EoS_AuxArray_Int,
+                                                   h_EoS_Table, NULL );
                }
 #              endif
 
@@ -278,7 +279,7 @@ void Flu_FixUp_Flux( const int lv )
 //                DE_ENPY only supports EOS_GAMMA, which does not involve passive scalars
                   CorrVal[ENPY] = Hydro_DensPres2Entropy( CorrVal[DENS],
                                                           EoS_DensEint2Pres_CPUPtr(CorrVal[DENS],Eint,NULL,
-                                                          EoS_AuxArray_Flt,EoS_AuxArray_Int,h_EoS_Table),
+                                                          EoS_AuxArray_Flt,EoS_AuxArray_Int,h_EoS_Table,NULL),
                                                           EoS_AuxArray_Flt[1] );
 #                 elif ( DUAL_ENERGY == DE_EINT )
 #                 error : DE_EINT is NOT supported yet !!

--- a/src/Fluid/Flu_ResetByUser.cpp
+++ b/src/Fluid/Flu_ResetByUser.cpp
@@ -56,7 +56,7 @@ bool Flu_ResetByUser_Func_Template( real fluid[], const double x, const double y
 #  endif
    const real MinPres                   = 1.0e-10;
    const real MinEint                   = EoS_DensPres2Eint_CPUPtr( MinDens, MinPres, MinPassive,
-                                                                    EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
+                                                                    EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table, NULL );
    const real MinEmag                   = 0.0;  // assuming MHD is not adopted
 
    if ( r <= TRad )

--- a/src/GPU_API/CUAPI_SendExtPotTable2GPU.cu
+++ b/src/GPU_API/CUAPI_SendExtPotTable2GPU.cu
@@ -15,6 +15,7 @@ extern real *d_ExtPotTable;
 // Description :  Send the external potential table to GPU
 //
 // Note        :  1. Invoked by Init_LoadExtPotTable()
+//                2. Use synchronous transfer
 //
 // Parameter   :  h_Table : Host array storing the input table
 //
@@ -25,7 +26,8 @@ void CUAPI_SendExtPotTable2GPU( const real *h_Table )
 
    const long MemSize = (long)sizeof(real)*EXT_POT_TABLE_NPOINT[0]*EXT_POT_TABLE_NPOINT[1]*EXT_POT_TABLE_NPOINT[2];
 
-   CUDA_CHECK_ERROR(  cudaMemcpyAsync( d_ExtPotTable, h_Table, MemSize, cudaMemcpyHostToDevice )  );
+// use synchronous transfer
+   CUDA_CHECK_ERROR(  cudaMemcpy( d_ExtPotTable, h_Table, MemSize, cudaMemcpyHostToDevice )  );
 
 } // FUNCTION : CUAPI_SendExtPotTable2GPU
 

--- a/src/Grackle/Grackle_Close.cpp
+++ b/src/Grackle/Grackle_Close.cpp
@@ -127,7 +127,7 @@ void Grackle_Close( const int lv, const int SaveSg, const real h_Che_Array[], co
 #           ifdef DUAL_ENERGY
 #           if   ( DUAL_ENERGY == DE_ENPY )
 //          DE_ENPY only works with EOS_GAMMA, which does not involve passive scalars
-            Pres = EoS_DensEint2Pres_CPUPtr( Dens, Eint, NULL, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
+            Pres = EoS_DensEint2Pres_CPUPtr( Dens, Eint, NULL, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table, NULL );
             *( fluid[ENPY     ][0][0] + idx_p ) = Hydro_DensPres2Entropy( Dens, Pres, EoS_AuxArray_Flt[1] );
 
 #           elif ( DUAL_ENERGY == DE_EINT )

--- a/src/Grackle/Grackle_Prepare.cpp
+++ b/src/Grackle/Grackle_Prepare.cpp
@@ -179,7 +179,7 @@ void Grackle_Prepare( const int lv, real h_Che_Array[], const int NPG, const int
 #           if   ( DUAL_ENERGY == DE_ENPY )
             Pres = Hydro_DensEntropy2Pres( Dens, *(fluid[ENPY][0][0]+idx_p), EoS_AuxArray_Flt[1], CheckMinPres_No, NULL_REAL );
 //          EOS_GAMMA does not involve passive scalars
-            Eint = EoS_DensPres2Eint_CPUPtr( Dens, Pres, NULL, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
+            Eint = EoS_DensPres2Eint_CPUPtr( Dens, Pres, NULL, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table, NULL );
 #           elif ( DUAL_ENERGY == DE_EINT )
 #           error : DE_EINT is NOT supported yet !!
 #           endif

--- a/src/Main/Main.cpp
+++ b/src/Main/Main.cpp
@@ -223,10 +223,12 @@ int    EoS_AuxArray_Int[EOS_NAUX_MAX];
 EoS_DE2P_t EoS_DensEint2Pres_CPUPtr = NULL;
 EoS_DP2E_t EoS_DensPres2Eint_CPUPtr = NULL;
 EoS_DP2C_t EoS_DensPres2CSqr_CPUPtr = NULL;
+EoS_GENE_t EoS_General_CPUPtr       = NULL;
 #ifdef GPU
 EoS_DE2P_t EoS_DensEint2Pres_GPUPtr = NULL;
 EoS_DP2E_t EoS_DensPres2Eint_GPUPtr = NULL;
 EoS_DP2C_t EoS_DensPres2CSqr_GPUPtr = NULL;
+EoS_GENE_t EoS_General_GPUPtr       = NULL;
 #endif
 
 // c. data structure for the CPU/GPU solvers

--- a/src/Model_Hydro/CPU_Hydro/CPU_FluidSolver_RTVD.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_FluidSolver_RTVD.cpp
@@ -241,7 +241,7 @@ void CPU_AdvanceX( real u[][ CUBE(FLU_NXT) ], const real dt, const real dx,
 #        endif
 
          c    = FABS( vx ) + SQRT(  EoS->DensPres2CSqr_FuncPtr( ux[0][i], p, Passive, EoS->AuxArrayDevPtr_Flt,
-                                                                EoS->AuxArrayDevPtr_Int, EoS->Table )  );
+                                                                EoS->AuxArrayDevPtr_Int, EoS->Table, NULL )  );
 
          cw[0][i] = ux[1][i];
          cw[1][i] = ux[1][i] * vx + p;
@@ -308,7 +308,7 @@ void CPU_AdvanceX( real u[][ CUBE(FLU_NXT) ], const real dt, const real dx,
 #        endif
 
          c    = FABS( vx ) + SQRT(  EoS->DensPres2CSqr_FuncPtr( u_half[0][i], p, Passive, EoS->AuxArrayDevPtr_Flt,
-                                                                EoS->AuxArrayDevPtr_Int, EoS->Table )  );
+                                                                EoS->AuxArrayDevPtr_Int, EoS->Table, NULL )  );
 
          cw[0][i] = u_half[1][i];
          cw[1][i] = u_half[1][i] * vx + p;

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_DataReconstruction.cpp
@@ -1297,7 +1297,7 @@ void Hydro_Pri2Char( real InOut[], const real Dens, const real Pres, const real 
 // b. pure hydro
 #  else // #ifdef MHD
    const real  a2 = EoS->DensPres2CSqr_FuncPtr( Dens, Pres, Passive, EoS->AuxArrayDevPtr_Flt,
-                                                EoS->AuxArrayDevPtr_Int, EoS->Table );
+                                                EoS->AuxArrayDevPtr_Int, EoS->Table, NULL );
    const real _a2 = (real)1.0 / a2;
    const real _a  = SQRT( _a2 );
 
@@ -1368,7 +1368,7 @@ void Hydro_Char2Pri( real InOut[], const real Dens, const real Pres, const real 
 
 // primitive --> characteristic
    const real a2 = EoS->DensPres2CSqr_FuncPtr( Dens, Pres, Passive, EoS->AuxArrayDevPtr_Flt,
-                                               EoS->AuxArrayDevPtr_Int, EoS->Table );
+                                               EoS->AuxArrayDevPtr_Int, EoS->Table, NULL );
 
 // a. MHD
 #  ifdef MHD
@@ -1465,7 +1465,7 @@ void Hydro_GetEigenSystem( const real CC_Var[], real EigenVal[][NWAVE],
    const real  Rho = CC_Var[0];
    const real _Rho = (real)1.0/Rho;
    const real  a2  = EoS->DensPres2CSqr_FuncPtr( Rho, CC_Var[4], Passive, EoS->AuxArrayDevPtr_Flt,
-                                                 EoS->AuxArrayDevPtr_Int, EoS->Table );
+                                                 EoS->AuxArrayDevPtr_Int, EoS->Table, NULL );
    const real  a   = SQRT( a2 );
    const real _a   = (real)1.0/a;
    const real _a2  = _a*_a;

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_FluUtility.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_FluUtility.cpp
@@ -195,7 +195,7 @@ void Hydro_Con2Pri( const real In[], real Out[], const real MinPres,
 
 //    recompute internal energy to be consistent with the updated pressure
       if ( EintOut != NULL  &&  Out[4] != Pres0 )
-         *EintOut = EoS_DensPres2Eint( Out[0], Out[4], In+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table );
+         *EintOut = EoS_DensPres2Eint( Out[0], Out[4], In+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table, NULL );
    }
 
 
@@ -283,7 +283,7 @@ void Hydro_Pri2Con( const real In[], real Out[], const bool NormPassive, const i
    Emag   = (real)0.5*( SQR(Bx) + SQR(By) + SQR(Bz) );
 #  endif
    Eint   = ( EintIn == NULL ) ? EoS_DensPres2Eint( In[0], In[4], Out+NCOMP_FLUID, EoS_AuxArray_Flt,
-                                                    EoS_AuxArray_Int, EoS_Table )
+                                                    EoS_AuxArray_Int, EoS_Table, NULL )
                                : *EintIn;
    Out[4] = Hydro_ConEint2Etot( Out[0], Out[1], Out[2], Out[3], Eint, Emag );
 
@@ -537,7 +537,7 @@ real Hydro_Con2Pres( const real Dens, const real MomX, const real MomY, const re
    real Eint, Pres;
 
    Eint = Hydro_Con2Eint( Dens, MomX, MomY, MomZ, Engy, CheckMinEint_No, NULL_REAL, Emag );
-   Pres = EoS_DensEint2Pres( Dens, Eint, Passive, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table );
+   Pres = EoS_DensEint2Pres( Dens, Eint, Passive, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table, NULL );
 
    if ( CheckMinPres )   Pres = Hydro_CheckMinPres( Pres, MinPres );
 

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_HLLC.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_HLLC.cpp
@@ -96,8 +96,8 @@ void Hydro_RiemannSolver_HLLC( const int XYZ, real Flux_Out[], const real L_In[]
                            EoS_DensEint2Pres, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table, NULL );
    P_R   = Hydro_Con2Pres( R[0], R[1], R[2], R[3], R[4], R+NCOMP_FLUID, CheckMinPres_Yes, MinPres, Emag,
                            EoS_DensEint2Pres, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table, NULL );
-   Cs_L  = SQRT(  EoS_DensPres2CSqr( L[0], P_L, L+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table )  );
-   Cs_R  = SQRT(  EoS_DensPres2CSqr( R[0], P_R, R+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table )  );
+   Cs_L  = SQRT(  EoS_DensPres2CSqr( L[0], P_L, L+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table, NULL )  );
+   Cs_R  = SQRT(  EoS_DensPres2CSqr( R[0], P_R, R+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table, NULL )  );
 
 #  ifdef CHECK_NEGATIVE_IN_FLUID
    if ( Hydro_CheckNegative(P_L) )
@@ -195,8 +195,8 @@ void Hydro_RiemannSolver_HLLC( const int XYZ, real Flux_Out[], const real L_In[]
    Rho_SR      = FMAX( Rho_SR, MinDens );
    _P          = ONE / P_PVRS;
 // see Eq. [9.8] in Toro 1999 for passive scalars
-   Gamma_SL    = EoS_DensPres2CSqr( Rho_SL, P_PVRS, L+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table )*Rho_SL*_P;
-   Gamma_SR    = EoS_DensPres2CSqr( Rho_SR, P_PVRS, R+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table )*Rho_SR*_P;
+   Gamma_SL    = EoS_DensPres2CSqr( Rho_SL, P_PVRS, L+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table, NULL )*Rho_SL*_P;
+   Gamma_SR    = EoS_DensPres2CSqr( Rho_SR, P_PVRS, R+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table, NULL )*Rho_SR*_P;
 #  endif // EOS
 
    q_L = ( P_PVRS <= P_L ) ? ONE : SQRT(  ONE + _TWO*( Gamma_SL + ONE )/Gamma_SL*( P_PVRS/P_L - ONE )  );

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_HLLD.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_HLLD.cpp
@@ -138,7 +138,7 @@ void Hydro_RiemannSolver_HLLD( const int XYZ, real Flux_Out[], const real L_In[]
    PT_L        = Pri_L[4] + B2L_d2;
    PT_R        = Pri_R[4] + B2R_d2;
 
-   a2          = EoS_DensPres2CSqr( Con_L[0], Pri_L[4], Con_L+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table );
+   a2          = EoS_DensPres2CSqr( Con_L[0], Pri_L[4], Con_L+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table, NULL );
    Cax2        = Bx2*_RhoL;
    Cat2        = BtL2*_RhoL;
    Ca2_plus_a2 = Cat2 + Cax2 + a2;
@@ -159,7 +159,7 @@ void Hydro_RiemannSolver_HLLD( const int XYZ, real Flux_Out[], const real L_In[]
 
    Cf_L = SQRT( Cf2 );  // Cf2 is positive definite using the above formula
 
-   a2          = EoS_DensPres2CSqr( Con_R[0], Pri_R[4], Con_R+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table );
+   a2          = EoS_DensPres2CSqr( Con_R[0], Pri_R[4], Con_R+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table, NULL );
    Cax2        = Bx2*_RhoR;
    Cat2        = BtR2*_RhoR;
    Ca2_plus_a2 = Cat2 + Cax2 + a2;

--- a/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_HLLE.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_Shared_RiemannSolver_HLLE.cpp
@@ -121,8 +121,8 @@ void Hydro_RiemannSolver_HLLE( const int XYZ, real Flux_Out[], const real L_In[]
                            EoS_DensEint2Pres, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table, NULL );
    P_R   = Hydro_Con2Pres( R[0], R[1], R[2], R[3], R[4], R+NCOMP_FLUID, CheckMinPres_Yes, MinPres, Emag_R,
                            EoS_DensEint2Pres, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table, NULL );
-   a2_L  = EoS_DensPres2CSqr( L[0], P_L, L+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table );
-   a2_R  = EoS_DensPres2CSqr( R[0], P_R, R+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table );
+   a2_L  = EoS_DensPres2CSqr( L[0], P_L, L+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table, NULL );
+   a2_R  = EoS_DensPres2CSqr( R[0], P_R, R+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table, NULL );
 
 #  ifdef CHECK_NEGATIVE_IN_FLUID
    if ( Hydro_CheckNegative(P_L) )
@@ -361,8 +361,8 @@ void Hydro_RiemannSolver_HLLE( const int XYZ, real Flux_Out[], const real L_In[]
    Rho_SR      = FMAX( Rho_SR, MinDens );
    _P          = ONE / P_PVRS;
 // see Eq. [9.8] in Toro 1999 for passive scalars
-   Gamma_SL    = EoS_DensPres2CSqr( Rho_SL, P_PVRS, L+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table )*Rho_SL*_P;
-   Gamma_SR    = EoS_DensPres2CSqr( Rho_SR, P_PVRS, R+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table )*Rho_SR*_P;
+   Gamma_SL    = EoS_DensPres2CSqr( Rho_SL, P_PVRS, L+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table, NULL )*Rho_SL*_P;
+   Gamma_SR    = EoS_DensPres2CSqr( Rho_SR, P_PVRS, R+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int, EoS_Table, NULL )*Rho_SR*_P;
 #  endif // EOS
 
    q_L    = ( P_PVRS <= P_L ) ? ONE : SQRT(  ONE + _TWO*( Gamma_SL + ONE )/Gamma_SL*( P_PVRS/P_L - ONE )  );

--- a/src/Model_Hydro/CPU_Hydro/CPU_dtSolver_HydroCFL.cpp
+++ b/src/Model_Hydro/CPU_Hydro/CPU_dtSolver_HydroCFL.cpp
@@ -111,7 +111,7 @@ void CPU_dtSolver_HydroCFL  ( real g_dt_Array[], const real g_Flu_Array[][FLU_NI
                                  CheckMinPres_Yes, MinPres, Emag,
                                  EoS.DensEint2Pres_FuncPtr, EoS.AuxArrayDevPtr_Flt, EoS.AuxArrayDevPtr_Int, EoS.Table, NULL );
          a2    = EoS.DensPres2CSqr_FuncPtr( fluid[DENS], Pres, fluid+NCOMP_FLUID, EoS.AuxArrayDevPtr_Flt, EoS.AuxArrayDevPtr_Int,
-                                            EoS.Table ); // sound speed squared
+                                            EoS.Table, NULL ); // sound speed squared
 
 //       compute the maximum information propagating speed
 //       --> hydro: bulk velocity + sound wave

--- a/src/Model_Hydro/GPU_Hydro/CUFLU_FluidSolver_RTVD.cu
+++ b/src/Model_Hydro/GPU_Hydro/CUFLU_FluidSolver_RTVD.cu
@@ -206,7 +206,7 @@ __device__ void CUFLU_Advance( real g_Fluid_In [][5][ CUBE(FLU_NXT) ],
                  Fluid[0], __FILE__, __LINE__, __FUNCTION__ );
 #     endif
       c    = FABS( vx ) + SQRT(  EoS->DensPres2CSqr_FuncPtr( Fluid[0], p, Passive, EoS->AuxArrayDevPtr_Flt,
-                                                             EoS->AuxArrayDevPtr_Int, EoS->Table )  );
+                                                             EoS->AuxArrayDevPtr_Int, EoS->Table, NULL )  );
 
       s_cw[ty][0][i] = Fluid[1];
       s_cw[ty][1][i] = Fluid[1]*vx + p;
@@ -271,7 +271,7 @@ __device__ void CUFLU_Advance( real g_Fluid_In [][5][ CUBE(FLU_NXT) ],
 #        endif
 
          c    = FABS( vx ) + SQRT(  EoS->DensPres2CSqr_FuncPtr( Fluid_half[0], p, Passive, EoS->AuxArrayDevPtr_Flt,
-                                                                EoS->AuxArrayDevPtr_Int, EoS->Table )  );
+                                                                EoS->AuxArrayDevPtr_Int, EoS->Table, NULL )  );
 
          s_cw[ty][0][i] = Fluid_half[1];
          s_cw[ty][1][i] = Fluid_half[1]*vx + p;

--- a/src/Model_Hydro/Hydro_Init_ByFunction_AssignData.cpp
+++ b/src/Model_Hydro/Hydro_Init_ByFunction_AssignData.cpp
@@ -85,7 +85,7 @@ void Init_Function_User_Template( real fluid[], const double x, const double y, 
    MomX = Dens*Vx;
    MomY = Dens*Vy;
    MomZ = Dens*Vz;
-   Eint = EoS_DensPres2Eint_CPUPtr( Dens, Pres, Passive, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
+   Eint = EoS_DensPres2Eint_CPUPtr( Dens, Pres, Passive, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table, NULL );
    Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, Emag0 );
 
 // store the results

--- a/src/Output/Output_DumpData_Part.cpp
+++ b/src/Output/Output_DumpData_Part.cpp
@@ -260,7 +260,7 @@ void WriteFile( FILE *File, const int lv, const int PID, const int i, const int 
                                      CheckMinPres_No, NULL_REAL, Emag, EoS_DensEint2Pres_CPUPtr,
                                      EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table, NULL );
    const real Cs   = SQRT(  EoS_DensPres2CSqr_CPUPtr( u[DENS], Pres, u+NCOMP_FLUID, EoS_AuxArray_Flt, EoS_AuxArray_Int,
-                                                      h_EoS_Table )  );
+                                                      h_EoS_Table, NULL )  );
    fprintf( File, " %13.6e %13.6e", Pres, Cs );
 #  endif
 

--- a/src/TestProblem/Hydro/AGORA_IsolatedGalaxy/Init_TestProb_Hydro_AGORA_IsolatedGalaxy.cpp
+++ b/src/TestProblem/Hydro/AGORA_IsolatedGalaxy/Init_TestProb_Hydro_AGORA_IsolatedGalaxy.cpp
@@ -365,8 +365,8 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
 
 // compute the total gas energy
    Eint = EoS_DensPres2Eint_CPUPtr( Dens, Pres, NULL, EoS_AuxArray_Flt,
-                                    EoS_AuxArray_Int, h_EoS_Table );    // assuming EoS requires no passive scalars
-   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );      // do NOT include magnetic energy here
+                                    EoS_AuxArray_Int, h_EoS_Table, NULL ); // assuming EoS requires no passive scalars
+   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );         // do NOT include magnetic energy here
 
 // set the output array
    fluid[DENS] = Dens;

--- a/src/TestProblem/Hydro/AcousticWave/Init_TestProb_Hydro_AcousticWave.cpp
+++ b/src/TestProblem/Hydro/AcousticWave/Init_TestProb_Hydro_AcousticWave.cpp
@@ -214,8 +214,8 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
    MomZ  = MomX;
    Pres  = P0 + P1*cos(Phase);
    Eint  = EoS_DensPres2Eint_CPUPtr( Dens, Pres, NULL, EoS_AuxArray_Flt,
-                                     EoS_AuxArray_Int, h_EoS_Table );   // assuming EoS requires no passive scalars
-   Etot  = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );     // do NOT include magnetic energy here
+                                     EoS_AuxArray_Int, h_EoS_Table, NULL );   // assuming EoS requires no passive scalars
+   Etot  = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );           // do NOT include magnetic energy here
 
 // set the output array
    fluid[DENS] = Dens;

--- a/src/TestProblem/Hydro/BlastWave/Init_TestProb_Hydro_BlastWave.cpp
+++ b/src/TestProblem/Hydro/BlastWave/Init_TestProb_Hydro_BlastWave.cpp
@@ -195,8 +195,8 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
    MomZ = 0.0;
    Pres = ( r <= Blast_Radius ) ? Blast_Pres_Exp : Blast_Pres_Bg;
    Eint = EoS_DensPres2Eint_CPUPtr( Dens, Pres, NULL, EoS_AuxArray_Flt,
-                                    EoS_AuxArray_Int, h_EoS_Table );    // assuming EoS requires no passive scalars
-   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );      // do NOT include magnetic energy here
+                                    EoS_AuxArray_Int, h_EoS_Table, NULL ); // assuming EoS requires no passive scalars
+   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );         // do NOT include magnetic energy here
 
 // set the output array
    fluid[DENS] = Dens;

--- a/src/TestProblem/Hydro/Caustic/Init_TestProb_Hydro_Caustic.cpp
+++ b/src/TestProblem/Hydro/Caustic/Init_TestProb_Hydro_Caustic.cpp
@@ -196,8 +196,8 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
    Dens = Caustic_Dens;
    Pres = Caustic_Pres;
    Eint = EoS_DensPres2Eint_CPUPtr( Dens, Pres, NULL, EoS_AuxArray_Flt,
-                                    EoS_AuxArray_Int, h_EoS_Table );    // assuming EoS requires no passive scalars
-   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );      // do NOT include magnetic energy here
+                                    EoS_AuxArray_Int, h_EoS_Table, NULL ); // assuming EoS requires no passive scalars
+   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );         // do NOT include magnetic energy here
 
 // set the output array
    fluid[DENS] = Dens;

--- a/src/TestProblem/Hydro/ClusterMerger_vs_Flash/Init_TestProb_ClusterMerger_vs_Flash.cpp
+++ b/src/TestProblem/Hydro/ClusterMerger_vs_Flash/Init_TestProb_ClusterMerger_vs_Flash.cpp
@@ -310,8 +310,8 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
 
 // compute the total gas energy
    Eint = EoS_DensPres2Eint_CPUPtr( Dens, Pres, NULL, EoS_AuxArray_Flt,
-                                    EoS_AuxArray_Int, h_EoS_Table );    // assuming EoS requires no passive scalars
-   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );      // do NOT include magnetic energy here
+                                    EoS_AuxArray_Int, h_EoS_Table, NULL ); // assuming EoS requires no passive scalars
+   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );         // do NOT include magnetic energy here
 
 // set the output array
    fluid[DENS] = Dens;

--- a/src/TestProblem/Hydro/CollidingJets/Init_TestProb_Hydro_CollidingJets.cpp
+++ b/src/TestProblem/Hydro/CollidingJets/Init_TestProb_Hydro_CollidingJets.cpp
@@ -275,8 +275,8 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
    MomZ = Dens*Jet_BgVel[2];
    Pres = Jet_BgPres;
    Eint = EoS_DensPres2Eint_CPUPtr( Dens, Pres, NULL, EoS_AuxArray_Flt,
-                                    EoS_AuxArray_Int, h_EoS_Table );    // assuming EoS requires no passive scalars
-   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );      // do NOT include magnetic energy here
+                                    EoS_AuxArray_Int, h_EoS_Table, NULL ); // assuming EoS requires no passive scalars
+   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );         // do NOT include magnetic energy here
 
 // set the output array
    fluid[DENS] = Dens;
@@ -402,7 +402,7 @@ bool Flu_ResetByUser_CollidingJets( real fluid[], const double x, const double y
 
 //       assuming EoS requires no passive scalars
          double Eint = EoS_DensPres2Eint_CPUPtr( Jet_SrcDens[n], Jet_SrcPres[n], NULL,
-                                                 EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
+                                                 EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table, NULL );
 
 //       do NOT include magnetic energy here
          fluid[ENGY] = Hydro_ConEint2Etot( fluid[DENS], fluid[MOMX], fluid[MOMY], fluid[MOMZ], Eint, 0.0 );

--- a/src/TestProblem/Hydro/GREP_MigrationTest/Init_TestProb_Hydro_GREP_MigrationTest.cpp
+++ b/src/TestProblem/Hydro/GREP_MigrationTest/Init_TestProb_Hydro_GREP_MigrationTest.cpp
@@ -191,8 +191,8 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
    Momz = Dens*Velr*z0/r;
 
    Eint = EoS_DensPres2Eint_CPUPtr( Dens, Pres, NULL, EoS_AuxArray_Flt,
-                                    EoS_AuxArray_Int, h_EoS_Table );    // assuming EoS requires no passive scalars
-   Etot = Hydro_ConEint2Etot( Dens, Momx, Momy, Momz, Eint, 0.0 );      // do NOT include magnetic energy here
+                                    EoS_AuxArray_Int, h_EoS_Table, NULL ); // assuming EoS requires no passive scalars
+   Etot = Hydro_ConEint2Etot( Dens, Momx, Momy, Momz, Eint, 0.0 );         // do NOT include magnetic energy here
 
 
    fluid[DENS] = Dens;

--- a/src/TestProblem/Hydro/JeansInstability/Init_TestProb_Hydro_JeansInstability.cpp
+++ b/src/TestProblem/Hydro/JeansInstability/Init_TestProb_Hydro_JeansInstability.cpp
@@ -265,8 +265,8 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
 
 // compute the total gas energy
    Eint = EoS_DensPres2Eint_CPUPtr( Dens, Pres, NULL, EoS_AuxArray_Flt,
-                                    EoS_AuxArray_Int, h_EoS_Table );    // assuming EoS requires no passive scalars
-   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );      // do NOT include magnetic energy here
+                                    EoS_AuxArray_Int, h_EoS_Table, NULL ); // assuming EoS requires no passive scalars
+   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );         // do NOT include magnetic energy here
 
 // set the output array
    fluid[DENS] = Dens;

--- a/src/TestProblem/Hydro/KelvinHelmholtzInstability/Init_TestProb_Hydro_KelvinHelmholtzInstability.cpp
+++ b/src/TestProblem/Hydro/KelvinHelmholtzInstability/Init_TestProb_Hydro_KelvinHelmholtzInstability.cpp
@@ -236,8 +236,8 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
 
 // compute the total gas energy
    Eint = EoS_DensPres2Eint_CPUPtr( Dens, Pres, NULL, EoS_AuxArray_Flt,
-                                    EoS_AuxArray_Int, h_EoS_Table );    // assuming EoS requires no passive scalars
-   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );      // do NOT include magnetic energy here
+                                    EoS_AuxArray_Int, h_EoS_Table, NULL ); // assuming EoS requires no passive scalars
+   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );         // do NOT include magnetic energy here
 
 // set the output array
    fluid[DENS] = Dens;

--- a/src/TestProblem/Hydro/MHD_ABC/Init_TestProb_Hydro_MHD_ABC.cpp
+++ b/src/TestProblem/Hydro/MHD_ABC/Init_TestProb_Hydro_MHD_ABC.cpp
@@ -190,8 +190,8 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
    MomZ = ABC_Rho0*ABC_V0/sqrt(3.0);
    Pres = ABC_P0;
    Eint = EoS_DensPres2Eint_CPUPtr( Dens, Pres, NULL, EoS_AuxArray_Flt,
-                                    EoS_AuxArray_Int, h_EoS_Table );    // assuming EoS requires no passive scalars
-   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );      // do NOT include magnetic energy here
+                                    EoS_AuxArray_Int, h_EoS_Table, NULL ); // assuming EoS requires no passive scalars
+   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );         // do NOT include magnetic energy here
 
 // set the output array
    fluid[DENS] = Dens;

--- a/src/TestProblem/Hydro/MHD_LinearWave/Init_TestProb_Hydro_MHD_LinearWave.cpp
+++ b/src/TestProblem/Hydro/MHD_LinearWave/Init_TestProb_Hydro_MHD_LinearWave.cpp
@@ -243,8 +243,8 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
 
 // compute the total gas energy
    Eint = EoS_DensPres2Eint_CPUPtr( Dens, Pres, NULL, EoS_AuxArray_Flt,
-                                    EoS_AuxArray_Int, h_EoS_Table );    // assuming EoS requires no passive scalars
-   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );      // do NOT include magnetic energy here
+                                    EoS_AuxArray_Int, h_EoS_Table, NULL ); // assuming EoS requires no passive scalars
+   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );         // do NOT include magnetic energy here
 
 // set the output array
    fluid[DENS] = Dens;

--- a/src/TestProblem/Hydro/MHD_OrszagTangVortex/Init_TestProb_Hydro_MHD_OrszagTangVortex.cpp
+++ b/src/TestProblem/Hydro/MHD_OrszagTangVortex/Init_TestProb_Hydro_MHD_OrszagTangVortex.cpp
@@ -184,8 +184,8 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
    MomZ = 0.0;
    Pres = OrszagTang_P0;
    Eint = EoS_DensPres2Eint_CPUPtr( Dens, Pres, NULL, EoS_AuxArray_Flt,
-                                    EoS_AuxArray_Int, h_EoS_Table );    // assuming EoS requires no passive scalars
-   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );      // do NOT include magnetic energy here
+                                    EoS_AuxArray_Int, h_EoS_Table, NULL ); // assuming EoS requires no passive scalars
+   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );         // do NOT include magnetic energy here
 
 // set the output array
    fluid[DENS] = Dens;

--- a/src/TestProblem/Hydro/Plummer/Init_TestProb_Hydro_Plummer.cpp
+++ b/src/TestProblem/Hydro/Plummer/Init_TestProb_Hydro_Plummer.cpp
@@ -408,8 +408,8 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
 
 // compute the total gas energy
    Eint = EoS_DensPres2Eint_CPUPtr( Dens, Pres, NULL, EoS_AuxArray_Flt,
-                                    EoS_AuxArray_Int, h_EoS_Table );    // assuming EoS requires no passive scalars
-   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );      // do NOT include magnetic energy here
+                                    EoS_AuxArray_Int, h_EoS_Table, NULL ); // assuming EoS requires no passive scalars
+   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );         // do NOT include magnetic energy here
 
 // set the output array
    fluid[DENS] = Dens;

--- a/src/TestProblem/Hydro/Riemann/Init_TestProb_Hydro_Riemann.cpp
+++ b/src/TestProblem/Hydro/Riemann/Init_TestProb_Hydro_Riemann.cpp
@@ -280,6 +280,9 @@ void SetParameter()
 
 #  ifdef MHD
    if (  (int)Riemann_Prob != RJ2A  &&  (int)Riemann_Prob != TORRILHON  &&  (int)Riemann_Prob != BRIO_WU  )
+#  if ( EOS == EOS_NUCLEAR )
+   if (  (int)Riemann_Prob != NUCLEAR1  &&  (int)Riemann_Prob != NUCLEAR2  )
+#  endif
       Aux_Message( stderr, "WARNING : B field is zero in the %s Riemann problem (Riemann_Prob = %d) !!\n",
                    Riemann_Name, Riemann_Prob );
 #  endif

--- a/src/TestProblem/Hydro/Riemann/Init_TestProb_Hydro_Riemann.cpp
+++ b/src/TestProblem/Hydro/Riemann/Init_TestProb_Hydro_Riemann.cpp
@@ -372,7 +372,7 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
 
 // compute and store the total gas energy
    Eint = EoS_DensPres2Eint_CPUPtr( fluid[DENS], Pres, fluid+NCOMP_FLUID,
-                                    EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
+                                    EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table, NULL );
 
 // do NOT include magnetic energy here
    fluid[ENGY] = Hydro_ConEint2Etot( fluid[DENS], fluid[MOMX], fluid[MOMY], fluid[MOMZ], Eint, 0.0 );

--- a/src/TestProblem/Template/Init_TestProb_Template.cpp
+++ b/src/TestProblem/Template/Init_TestProb_Template.cpp
@@ -190,8 +190,8 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
    MomZ = 0.0;
    Pres = 2.0;
    Eint = EoS_DensPres2Eint_CPUPtr( Dens, Pres, NULL, EoS_AuxArray_Flt,
-                                    EoS_AuxArray_Int, h_EoS_Table );    // assuming EoS requires no passive scalars
-   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );      // do NOT include magnetic energy here
+                                    EoS_AuxArray_Int, h_EoS_Table, NULL ); // assuming EoS requires no passive scalars
+   Etot = Hydro_ConEint2Etot( Dens, MomX, MomY, MomZ, Eint, 0.0 );         // do NOT include magnetic energy here
 
 // set the output array
    fluid[DENS] = Dens;


### PR DESCRIPTION
- Implement a general EoS converter `EoS_General_Nuclear()` to support both the temperature and entropy modes in the nuclear EoS.
- Add a new function parameter `ExtraInOut[]` in the build-in EoS converters for future usage. 