### PR TITLE
Change the default value of GFUNC_COEFF0 to 3.8 for Model_ELBDM

### DIFF
--- a/src/Init/Init_ResetParameter.cpp
+++ b/src/Init/Init_ResetParameter.cpp
@@ -361,6 +361,8 @@ void Init_ResetParameter()
          case ( PAR_INTERP_TSC ):   GFUNC_COEFF0 = 4.8;   break;
          default: Aux_Error( ERROR_INFO, "unsupported particle interpolation scheme !!\n" );
       }
+#     elif ( MODEL == ELBDM )
+      GFUNC_COEFF0 = 3.8;
 #     else
       GFUNC_COEFF0 = 0.0;
 #     endif


### PR DESCRIPTION
For Model_ELBDM, the Green's function coefficient at the origin for the isolated BC does't matter when the resolution is high, but it should not be zero for a low-resolution situation.
The default value 3.8 was determined by tests with different resolution so it can be applied to most cases.