### PR TITLE
General potential table for `ExtPot_*`

### DIFF
--- a/include/Global.h
+++ b/include/Global.h
@@ -301,6 +301,7 @@ extern char       (*h_DE_Array_G      [2])[PS1][PS1][PS1];
 extern real       (*h_Emag_Array_G    [2])[PS1][PS1][PS1];
 #endif
 extern real        *h_ExtPotTable;
+extern void       **h_GenePotTable;
 
 #ifdef UNSPLIT_GRAVITY
 extern real       (*h_Pot_Array_USG_F [2])[ CUBE(USG_NXT_F) ];

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -324,7 +324,8 @@ void CPU_PoissonGravitySolver( const real h_Rho_Array    [][RHO_NXT][RHO_NXT][RH
                                const bool SelfGravity, const OptExtPot_t ExtPot, const OptExtAcc_t ExtAcc,
                                const double TimeNew, const double TimeOld, const real MinEint );
 void CPU_ExtPotSolver_BaseLevel( const ExtPot_t Func, const double AuxArray_Flt[], const int AuxArray_Int[],
-                                 const real Table[], const double Time, const bool PotIsInit, const int SaveSg );
+                                 const real Table[], void **GeneTable,
+                                 const double Time, const bool PotIsInit, const int SaveSg );
 void CPU_PoissonSolver_FFT( const real Poi_Coeff, const int SaveSg, const double PrepTime );
 void Patch2Slab( real *RhoK, real *SendBuf_Rho, real *RecvBuf_Rho, long *SendBuf_SIdx, long *RecvBuf_SIdx,
                  int **List_PID, int **List_k, int *List_NSend_Rho, int *List_NRecv_Rho,

--- a/include/Typedef.h
+++ b/include/Typedef.h
@@ -396,7 +396,7 @@ typedef void (*ExtAcc_t)( real Acc[], const double x, const double y, const doub
                           const double UserArray[] );
 typedef real (*ExtPot_t)( const double x, const double y, const double z, const double Time,
                           const double UserArray_Flt[], const int UserArray_Int[],
-                          const ExtPotUsage_t Usage, const real PotTable[] );
+                          const ExtPotUsage_t Usage, const real PotTable[], void **GenePotTable );
 
 
 // options in Aux_ComputeProfile()

--- a/src/GPU_API/CUAPI_Asyn_PoissonGravitySolver.cu
+++ b/src/GPU_API/CUAPI_Asyn_PoissonGravitySolver.cu
@@ -34,6 +34,7 @@ __global__
 void CUPOT_ExtPotSolver( real g_Pot_Array[][ CUBE(GRA_NXT) ],
                          const double g_Corner_Array[][3],
                          const real g_ExtPotTable[],
+                         void **g_GenePotTable,
                          const real dh, const ExtPot_t ExtPot_Func,
                          const double Time, const bool PotIsInit );
 
@@ -91,6 +92,7 @@ static real (*d_Emag_Array_G)[ CUBE(PS1) ] = NULL;
 #endif
 #endif // #if ( MODEL == HYDRO )
 extern real  *d_ExtPotTable;
+extern void **d_GenePotTable;
 
 extern cudaStream_t *Stream;
 
@@ -238,8 +240,10 @@ void CUAPI_Asyn_PoissonGravitySolver( const real h_Rho_Array    [][RHO_NXT][RHO_
       {
          if ( h_Corner_Array     == NULL )   Aux_Error( ERROR_INFO, "h_Corner_Array == NULL !!\n" );
          if ( d_Corner_Array_PGT == NULL )   Aux_Error( ERROR_INFO, "d_Corner_Array_PGT == NULL !!\n" );
-         if ( ExtPot == EXT_POT_TABLE  &&  d_ExtPotTable == NULL )
+         if ( ExtPot == EXT_POT_TABLE  &&  d_ExtPotTable  == NULL )
                                              Aux_Error( ERROR_INFO, "d_ExtPotTable == NULL !!\n" );
+         if ( ExtPot == EXT_POT_GREP   &&  d_GenePotTable == NULL )
+                                             Aux_Error( ERROR_INFO, "d_GenePotTable == NULL !!\n" );
       }
    } // if ( Poisson )
 
@@ -441,7 +445,7 @@ void CUAPI_Asyn_PoissonGravitySolver( const real h_Rho_Array    [][RHO_NXT][RHO_
             CUPOT_ExtPotSolver <<< NPatch_per_Stream[s], ExtPot_Block_Dim, 0, Stream[s] >>>
                                ( d_Pot_Array_P_Out  + UsedPatch[s],
                                  d_Corner_Array_PGT + UsedPatch[s],
-                                 d_ExtPotTable,
+                                 d_ExtPotTable, d_GenePotTable,
                                  dh, GPUExtPot_Ptr, TimeNew, SelfGravity );
          }
       } // if ( Poisson )

--- a/src/GPU_API/CUAPI_MemAllocate_PoissonGravity.cu
+++ b/src/GPU_API/CUAPI_MemAllocate_PoissonGravity.cu
@@ -53,7 +53,7 @@ void CUAPI_MemAllocate_PoissonGravity( const int Pot_NPG )
 #  endif
    const long Pot_MemSize_T     = sizeof(real  )*Pot_NP*CUBE(GRA_NXT);
    const long ExtPot_MemSize    = (long)sizeof(real)*EXT_POT_TABLE_NPOINT[0]*EXT_POT_TABLE_NPOINT[1]*EXT_POT_TABLE_NPOINT[2];
-   const long GenePot_MemSize   = 6*sizeof(void*);
+   const long GenePot_MemSize   = sizeof(void* )*6;
 
 
 // output the total memory requirement

--- a/src/GPU_API/CUAPI_MemAllocate_PoissonGravity.cu
+++ b/src/GPU_API/CUAPI_MemAllocate_PoissonGravity.cu
@@ -21,6 +21,7 @@ extern real (*d_Emag_Array_G   )[ CUBE(PS1) ];
 #endif
 extern real (*d_Pot_Array_T)    [ CUBE(GRA_NXT) ];
 extern real  *d_ExtPotTable;
+extern void **d_GenePotTable;
 
 
 
@@ -52,6 +53,7 @@ void CUAPI_MemAllocate_PoissonGravity( const int Pot_NPG )
 #  endif
    const long Pot_MemSize_T     = sizeof(real  )*Pot_NP*CUBE(GRA_NXT);
    const long ExtPot_MemSize    = (long)sizeof(real)*EXT_POT_TABLE_NPOINT[0]*EXT_POT_TABLE_NPOINT[1]*EXT_POT_TABLE_NPOINT[2];
+   const long GenePot_MemSize   = 6*sizeof(void*);
 
 
 // output the total memory requirement
@@ -67,6 +69,8 @@ void CUAPI_MemAllocate_PoissonGravity( const int Pot_NPG )
 #  endif
    if ( OPT__EXT_POT == EXT_POT_TABLE )
    TotalSize += ExtPot_MemSize;
+   if ( OPT__EXT_POT == EXT_POT_GREP )
+   TotalSize += GenePot_MemSize;
 
    if ( MPI_Rank == 0 )
       Aux_Message( stdout, "NOTE : total memory requirement in GPU Poisson and gravity solver = %ld MB\n",
@@ -91,13 +95,16 @@ void CUAPI_MemAllocate_PoissonGravity( const int Pot_NPG )
 #  endif
 
 #  ifdef MHD
-   CUDA_CHECK_ERROR(  cudaMalloc( (void**) &d_Emag_Array_G,     Emag_MemSize_G   )  );
+   CUDA_CHECK_ERROR(  cudaMalloc( (void**) &d_Emag_Array_G,     Emag_MemSize_G    )  );
 #  endif
 
    CUDA_CHECK_ERROR(  cudaMalloc( (void**) &d_Pot_Array_T,      Pot_MemSize_T     )  );
 
    if ( OPT__EXT_POT == EXT_POT_TABLE )
    CUDA_CHECK_ERROR(  cudaMalloc( (void**) &d_ExtPotTable,      ExtPot_MemSize    )  );
+
+   if ( OPT__EXT_POT == EXT_POT_GREP )
+   CUDA_CHECK_ERROR(  cudaMalloc( (void**) &d_GenePotTable,     GenePot_MemSize   )  );
 
 
 // allocate the host memory by CUDA
@@ -128,6 +135,9 @@ void CUAPI_MemAllocate_PoissonGravity( const int Pot_NPG )
 
    if ( OPT__EXT_POT == EXT_POT_TABLE )
       CUDA_CHECK_ERROR(  cudaMallocHost( (void**) &h_ExtPotTable,         ExtPot_MemSize    )  );
+
+   if ( OPT__EXT_POT == EXT_POT_GREP )
+      CUDA_CHECK_ERROR(  cudaMallocHost( (void**) &h_GenePotTable,        GenePot_MemSize   )  );
 
 } // FUNCTION : CUAPI_MemAllocate_PoissonGravity
 

--- a/src/GPU_API/CUAPI_MemFree_PoissonGravity.cu
+++ b/src/GPU_API/CUAPI_MemFree_PoissonGravity.cu
@@ -22,6 +22,7 @@ extern real (*d_Emag_Array_G   )[ CUBE(PS1) ];
 #endif
 extern real (*d_Pot_Array_T    )[ CUBE(GRA_NXT) ];
 extern real  *d_ExtPotTable;
+extern void **d_GenePotTable;
 
 
 
@@ -54,6 +55,7 @@ void CUAPI_MemFree_PoissonGravity()
 #  endif
    if ( d_Pot_Array_T      != NULL ) {  CUDA_CHECK_ERROR(  cudaFree( d_Pot_Array_T      )  );  d_Pot_Array_T      = NULL; }
    if ( d_ExtPotTable      != NULL ) {  CUDA_CHECK_ERROR(  cudaFree( d_ExtPotTable      )  );  d_ExtPotTable      = NULL; }
+   if ( d_GenePotTable     != NULL ) {  CUDA_CHECK_ERROR(  cudaFree( d_GenePotTable     )  );  d_GenePotTable     = NULL; }
 
 
 // free the host memory allocated by CUDA
@@ -79,6 +81,7 @@ void CUAPI_MemFree_PoissonGravity()
    } // for (int t=0; t<2; t++)
 
       if ( h_ExtPotTable         != NULL ) {  CUDA_CHECK_ERROR(  cudaFreeHost( h_ExtPotTable         )  );  h_ExtPotTable         = NULL; }
+      if ( h_GenePotTable        != NULL ) {  CUDA_CHECK_ERROR(  cudaFreeHost( h_GenePotTable        )  );  h_GenePotTable        = NULL; }
 
 } // FUNCTION : CUAPI_MemFree_PoissonGravity
 

--- a/src/Main/Main.cpp
+++ b/src/Main/Main.cpp
@@ -296,6 +296,7 @@ char   (*h_DE_Array_G      [2])[PS1][PS1][PS1]                     = { NULL, NUL
 real   (*h_Emag_Array_G    [2])[PS1][PS1][PS1]                     = { NULL, NULL };
 #endif
 real    *h_ExtPotTable                                             = NULL;
+void   **h_GenePotTable                                            = NULL;
 
 // (3-3) unsplit gravity correction
 #ifdef UNSPLIT_GRAVITY
@@ -381,6 +382,7 @@ char   (*d_DE_Array_G     )[ CUBE(PS1) ]                           = NULL;
 real   (*d_Emag_Array_G   )[ CUBE(PS1) ]                           = NULL;
 #endif
 real    *d_ExtPotTable                                             = NULL;
+void   **d_GenePotTable                                            = NULL;
 
 // (4-3) unsplit gravity correction
 #ifdef UNSPLIT_GRAVITY

--- a/src/SelfGravity/CPU_Poisson/CPU_ExtPotSolver.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_ExtPotSolver.cpp
@@ -24,7 +24,7 @@
 // Parameter   :  g_Pot_Array               : Array storing the input and output potential data of each target patch
 //                g_Corner_Array            : Array storing the physical corner coordinates of each patch
 //                g_ExtPotTable             : Array storing the external potential 3D table
-//                g_GenePotTable            : Array storing the pointers to general potential table
+//                g_GenePotTable            : Array storing the pointers to general potential tables
 //                NPatchGroup               : Number of target patch groups (for CPU only)
 //                dh                        : Cell size
 //                ExtPot_Func               : Function pointer to the external potential routine (for both CPU and GPU)

--- a/src/SelfGravity/CPU_Poisson/CPU_ExtPotSolver.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_ExtPotSolver.cpp
@@ -24,6 +24,7 @@
 // Parameter   :  g_Pot_Array               : Array storing the input and output potential data of each target patch
 //                g_Corner_Array            : Array storing the physical corner coordinates of each patch
 //                g_ExtPotTable             : Array storing the external potential 3D table
+//                g_GenePotTable            : Array storing the pointers to general potential table
 //                NPatchGroup               : Number of target patch groups (for CPU only)
 //                dh                        : Cell size
 //                ExtPot_Func               : Function pointer to the external potential routine (for both CPU and GPU)
@@ -42,12 +43,14 @@ __global__
 void CUPOT_ExtPotSolver( real g_Pot_Array[][ CUBE(GRA_NXT) ],
                          const double g_Corner_Array[][3],
                          const real g_ExtPotTable[],
+                         void **g_GenePotTable,
                          const real dh, const ExtPot_t ExtPot_Func,
                          const double Time, const bool PotIsInit )
 #else
 void CPU_ExtPotSolver  ( real g_Pot_Array[][ CUBE(GRA_NXT) ],
                          const double g_Corner_Array[][3],
                          const real g_ExtPotTable[],
+                         void **g_GenePotTable,
                          const int NPatchGroup,
                          const real dh, const ExtPot_t ExtPot_Func,
                          const double c_ExtPot_AuxArray_Flt[],
@@ -84,7 +87,8 @@ void CPU_ExtPotSolver  ( real g_Pot_Array[][ CUBE(GRA_NXT) ],
          y = y0 + double(j*dh);
          z = z0 + double(k*dh);
 
-         ExtPot = ExtPot_Func( x, y, z, Time, c_ExtPot_AuxArray_Flt, c_ExtPot_AuxArray_Int, EXT_POT_USAGE_ADD, g_ExtPotTable );
+         ExtPot = ExtPot_Func( x, y, z, Time, c_ExtPot_AuxArray_Flt, c_ExtPot_AuxArray_Int, EXT_POT_USAGE_ADD,
+                               g_ExtPotTable, g_GenePotTable );
 
          if ( PotIsInit )  g_Pot_Array[P][t] += ExtPot;  // add to the input potential
          else              g_Pot_Array[P][t]  = ExtPot;  // overwrite the input potential

--- a/src/SelfGravity/CPU_Poisson/CPU_ExtPotSolver_BaseLevel.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_ExtPotSolver_BaseLevel.cpp
@@ -17,6 +17,7 @@
 // Parameter   :  Func             : Function pointer to the external potential routine
 //                AuxArray_Flt/Int : Auxiliary floating-point/integer arrays for adding external potential
 //                Table            : 3D potential table for EXT_POT_TABLE
+//                GeneTable        : Array of pointers for general potential table
 //                Time             : Target physical time
 //                PotIsInit        : Whether patch->pot[] has been initialized
 //                                   --> true : **add** to the original data
@@ -26,7 +27,8 @@
 // Return      :  amr->patch->pot[]
 //-----------------------------------------------------------------------------------------
 void CPU_ExtPotSolver_BaseLevel( const ExtPot_t Func, const double AuxArray_Flt[], const int AuxArray_Int[],
-                                 const real Table[], const double Time, const bool PotIsInit, const int SaveSg )
+                                 const real Table[], void **GeneTable,
+                                 const double Time, const bool PotIsInit, const int SaveSg )
 {
 
 // check
@@ -69,7 +71,7 @@ void CPU_ExtPotSolver_BaseLevel( const ExtPot_t Func, const double AuxArray_Flt[
          for (int j=0; j<PS1; j++)  {  y = y0 + j*dh;
          for (int i=0; i<PS1; i++)  {  x = x0 + i*dh;
 
-            ExtPot = Func( x, y, z, Time, AuxArray_Flt, AuxArray_Int, EXT_POT_USAGE_ADD, Table );
+            ExtPot = Func( x, y, z, Time, AuxArray_Flt, AuxArray_Int, EXT_POT_USAGE_ADD, Table, GeneTable );
 
             if ( PotIsInit )  amr->patch[SaveSg][lv][PID]->pot[k][j][i] += ExtPot;  // add
             else              amr->patch[SaveSg][lv][PID]->pot[k][j][i]  = ExtPot;  // overwrite

--- a/src/SelfGravity/CPU_Poisson/CPU_ExtPotSolver_BaseLevel.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_ExtPotSolver_BaseLevel.cpp
@@ -17,7 +17,7 @@
 // Parameter   :  Func             : Function pointer to the external potential routine
 //                AuxArray_Flt/Int : Auxiliary floating-point/integer arrays for adding external potential
 //                Table            : 3D potential table for EXT_POT_TABLE
-//                GeneTable        : Array of pointers for general potential table
+//                GeneTable        : Array of pointers for general potential tables
 //                Time             : Target physical time
 //                PotIsInit        : Whether patch->pot[] has been initialized
 //                                   --> true : **add** to the original data

--- a/src/SelfGravity/CPU_Poisson/CPU_ExtPot_GREP.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_ExtPot_GREP.cpp
@@ -165,13 +165,14 @@ void SetExtPotAuxArray_GREP( double AuxArray_Flt[], int AuxArray_Int[] )
 //                                        EXT_POT_USAGE_SUB_TINT: like SUB but for temporal interpolation
 //                                    --> This parameter is useless in most cases
 //                PotTable          : 3D potential table used by EXT_POT_TABLE
+//                GenePotTable      : Array of pointers for general potential table
 //
 // Return      :  External potential at (x,y,z,Time)
 //-----------------------------------------------------------------------------------------
 GPU_DEVICE_NOINLINE
 static real ExtPot_GREP( const double x, const double y, const double z, const double Time,
                          const double UserArray_Flt[], const int UserArray_Int[],
-                         const ExtPotUsage_t Usage, const real PotTable[] )
+                         const ExtPotUsage_t Usage, const real PotTable[], void **GenePotTable )
 {
 
    int     NBin;

--- a/src/SelfGravity/CPU_Poisson/CPU_ExtPot_GREP.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_ExtPot_GREP.cpp
@@ -165,7 +165,7 @@ void SetExtPotAuxArray_GREP( double AuxArray_Flt[], int AuxArray_Int[] )
 //                                        EXT_POT_USAGE_SUB_TINT: like SUB but for temporal interpolation
 //                                    --> This parameter is useless in most cases
 //                PotTable          : 3D potential table used by EXT_POT_TABLE
-//                GenePotTable      : Array of pointers for general potential table
+//                GenePotTable      : Array of pointers for general potential tables
 //
 // Return      :  External potential at (x,y,z,Time)
 //-----------------------------------------------------------------------------------------

--- a/src/SelfGravity/CPU_Poisson/CPU_ExtPot_PointMass.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_ExtPot_PointMass.cpp
@@ -96,13 +96,14 @@ void SetExtPotAuxArray_PointMass( double AuxArray_Flt[], int AuxArray_Int[] )
 //                                        EXT_POT_USAGE_SUB_TINT: like SUB but for temporal interpolation
 //                                    --> This parameter is useless in most cases
 //                PotTable          : 3D potential table used by EXT_POT_TABLE
+//                GenePotTable      : Array of pointers for general potential table
 //
 // Return      :  External potential at (x,y,z,Time)
 //-----------------------------------------------------------------------------------------
 GPU_DEVICE_NOINLINE
 static real ExtPot_PointMass( const double x, const double y, const double z, const double Time,
                               const double UserArray_Flt[], const int UserArray_Int[],
-                              const ExtPotUsage_t Usage, const real PotTable[] )
+                              const ExtPotUsage_t Usage, const real PotTable[], void **GenePotTable )
 {
 
    const double Cen[3] = { UserArray_Flt[0], UserArray_Flt[1], UserArray_Flt[2] };

--- a/src/SelfGravity/CPU_Poisson/CPU_ExtPot_PointMass.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_ExtPot_PointMass.cpp
@@ -96,7 +96,7 @@ void SetExtPotAuxArray_PointMass( double AuxArray_Flt[], int AuxArray_Int[] )
 //                                        EXT_POT_USAGE_SUB_TINT: like SUB but for temporal interpolation
 //                                    --> This parameter is useless in most cases
 //                PotTable          : 3D potential table used by EXT_POT_TABLE
-//                GenePotTable      : Array of pointers for general potential table
+//                GenePotTable      : Array of pointers for general potential tables
 //
 // Return      :  External potential at (x,y,z,Time)
 //-----------------------------------------------------------------------------------------

--- a/src/SelfGravity/CPU_Poisson/CPU_ExtPot_Tabular.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_ExtPot_Tabular.cpp
@@ -91,13 +91,14 @@ void SetExtPotAuxArray_Tabular( double AuxArray_Flt[], int AuxArray_Int[] )
 //                                        EXT_POT_USAGE_SUB_TINT: like SUB but for temporal interpolation
 //                                    --> This parameter is useless in most cases
 //                PotTable          : 3D potential table used by EXT_POT_TABLE
+//                GenePotTable      : Array of pointers for general potential table
 //
 // Return      :  External potential at (x,y,z,Time)
 //-----------------------------------------------------------------------------------------
 GPU_DEVICE_NOINLINE
 static real ExtPot_Tabular( const double x, const double y, const double z, const double Time,
                             const double UserArray_Flt[], const int UserArray_Int[],
-                            const ExtPotUsage_t Usage, const real PotTable[] )
+                            const ExtPotUsage_t Usage, const real PotTable[], void **GenePotTable )
 {
 
    const double EdgeL_x  = UserArray_Flt[0];

--- a/src/SelfGravity/CPU_Poisson/CPU_ExtPot_Tabular.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_ExtPot_Tabular.cpp
@@ -91,7 +91,7 @@ void SetExtPotAuxArray_Tabular( double AuxArray_Flt[], int AuxArray_Int[] )
 //                                        EXT_POT_USAGE_SUB_TINT: like SUB but for temporal interpolation
 //                                    --> This parameter is useless in most cases
 //                PotTable          : 3D potential table used by EXT_POT_TABLE
-//                GenePotTable      : Array of pointers for general potential table
+//                GenePotTable      : Array of pointers for general potential tables
 //
 // Return      :  External potential at (x,y,z,Time)
 //-----------------------------------------------------------------------------------------

--- a/src/SelfGravity/CPU_Poisson/CPU_PoissonGravitySolver.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_PoissonGravitySolver.cpp
@@ -24,6 +24,7 @@ void CPU_PoissonSolver_MG( const real Rho_Array    [][RHO_NXT][RHO_NXT][RHO_NXT]
 void CPU_ExtPotSolver( real g_Pot_Array[][ CUBE(GRA_NXT) ],
                        const double g_Corner_Array[][3],
                        const real g_ExtPotTable[],
+                       void **g_GenePotTable,
                        const int NPatchGroup,
                        const real dh, const ExtPot_t ExtPot_Func,
                        const double c_ExtPot_AuxArray_Flt[],
@@ -189,7 +190,7 @@ void CPU_PoissonGravitySolver( const real h_Rho_Array    [][RHO_NXT][RHO_NXT][RH
 
       if ( ExtPot )
       {
-         CPU_ExtPotSolver( (real(*)[ CUBE(GRA_NXT) ])h_Pot_Array_Out, h_Corner_Array, h_ExtPotTable,
+         CPU_ExtPotSolver( (real(*)[ CUBE(GRA_NXT) ])h_Pot_Array_Out, h_Corner_Array, h_ExtPotTable, h_GenePotTable,
                            NPatchGroup, dh, CPUExtPot_Ptr, ExtPot_AuxArray_Flt, ExtPot_AuxArray_Int,
                            TimeNew, SelfGravity );
       }

--- a/src/SelfGravity/End_MemFree_PoissonGravity.cpp
+++ b/src/SelfGravity/End_MemFree_PoissonGravity.cpp
@@ -34,8 +34,9 @@ void End_MemFree_PoissonGravity()
       delete [] h_Pot_Array_T     [t];  h_Pot_Array_T     [t] = NULL;
    }
 
-   delete [] GreenFuncK;     GreenFuncK    = NULL;
-   delete [] h_ExtPotTable;  h_ExtPotTable = NULL;
+   delete [] GreenFuncK;     GreenFuncK     = NULL;
+   delete [] h_ExtPotTable;  h_ExtPotTable  = NULL;
+   delete [] h_GenePotTable; h_GenePotTable = NULL;
 
 } // FUNCTION : End_MemFree_PoissonGravity
 

--- a/src/SelfGravity/Gra_AdvanceDt.cpp
+++ b/src/SelfGravity/Gra_AdvanceDt.cpp
@@ -121,7 +121,8 @@ void Gra_AdvanceDt( const int lv, const double TimeNew, const double TimeOld, co
                         Timer_Gra_Advance[lv],   Timing   );
 
          if ( OPT__EXT_POT )
-         TIMING_FUNC(   CPU_ExtPotSolver_BaseLevel( CPUExtPot_Ptr, ExtPot_AuxArray_Flt, ExtPot_AuxArray_Int, h_ExtPotTable,
+         TIMING_FUNC(   CPU_ExtPotSolver_BaseLevel( CPUExtPot_Ptr, ExtPot_AuxArray_Flt, ExtPot_AuxArray_Int,
+                                                    h_ExtPotTable, h_GenePotTable,
                                                     TimeNew, OPT__SELF_GRAVITY, SaveSg_Pot ),
                         Timer_Gra_Advance[lv],   Timing   );
 

--- a/src/SelfGravity/Init_MemAllocate_PoissonGravity.cpp
+++ b/src/SelfGravity/Init_MemAllocate_PoissonGravity.cpp
@@ -62,7 +62,7 @@ void Init_MemAllocate_PoissonGravity( const int Pot_NPG )
 
       const long TableSize = 6*sizeof(void*);
 
-      h_GenePotTable = new void [TableSize];
+      h_GenePotTable = new void* [TableSize];
    }
 
 } // FUNCTION : Init_MemAllocate_PoissonGravity

--- a/src/SelfGravity/Init_MemAllocate_PoissonGravity.cpp
+++ b/src/SelfGravity/Init_MemAllocate_PoissonGravity.cpp
@@ -56,6 +56,15 @@ void Init_MemAllocate_PoissonGravity( const int Pot_NPG )
       h_ExtPotTable = new real [TableSize];
    }
 
+
+// general potential table
+   if ( OPT__EXT_POT == EXT_POT_GREP ) {
+
+      const long TableSize = 6*sizeof(void*);
+
+      h_GenePotTable = new void [TableSize];
+   }
+
 } // FUNCTION : Init_MemAllocate_PoissonGravity
 
 

--- a/src/SelfGravity/Poi_Prepare_Pot.cpp
+++ b/src/SelfGravity/Poi_Prepare_Pot.cpp
@@ -172,7 +172,7 @@ void Poi_Prepare_Pot( const int lv, const double PrepTime, real h_Pot_Array_P_In
 //          subtract external potential
             if ( OPT__EXT_POT )
                CPot[ko][jo][io] -= CPUExtPot_Ptr( x, y, z, amr->PotSgTime[FaLv][PotSg], ExtPot_AuxArray_Flt, ExtPot_AuxArray_Int,
-                                                  EXT_POT_USAGE_SUB, h_ExtPotTable );
+                                                  EXT_POT_USAGE_SUB, h_ExtPotTable, h_GenePotTable );
 
 //          temporal interpolation
             if ( PotIntTime )
@@ -182,7 +182,7 @@ void Poi_Prepare_Pot( const int lv, const double PrepTime, real h_Pot_Array_P_In
 //             subtract external potential
                if ( OPT__EXT_POT )
                   CPot_IntT -= CPUExtPot_Ptr( x, y, z, amr->PotSgTime[FaLv][PotSg_IntT], ExtPot_AuxArray_Flt, ExtPot_AuxArray_Int,
-                                              EXT_POT_USAGE_SUB_TINT, h_ExtPotTable );
+                                              EXT_POT_USAGE_SUB_TINT, h_ExtPotTable, h_GenePotTable );
 
                CPot[ko][jo][io] =   PotWeighting     *CPot[ko][jo][io]
                                   + PotWeighting_IntT*CPot_IntT;
@@ -221,7 +221,7 @@ void Poi_Prepare_Pot( const int lv, const double PrepTime, real h_Pot_Array_P_In
 //                subtract external potential
                   if ( OPT__EXT_POT )
                      CPot[ko][jo][io] -= CPUExtPot_Ptr( x, y, z, amr->PotSgTime[FaLv][PotSg], ExtPot_AuxArray_Flt, ExtPot_AuxArray_Int,
-                                                        EXT_POT_USAGE_SUB, h_ExtPotTable );
+                                                        EXT_POT_USAGE_SUB, h_ExtPotTable, h_GenePotTable );
 
 //                temporal interpolation
                   if ( PotIntTime )
@@ -231,7 +231,7 @@ void Poi_Prepare_Pot( const int lv, const double PrepTime, real h_Pot_Array_P_In
 //                   subtract external potential
                      if ( OPT__EXT_POT )
                         CPot_IntT -= CPUExtPot_Ptr( x, y, z, amr->PotSgTime[FaLv][PotSg_IntT], ExtPot_AuxArray_Flt, ExtPot_AuxArray_Int,
-                                                    EXT_POT_USAGE_SUB_TINT, h_ExtPotTable );
+                                                    EXT_POT_USAGE_SUB_TINT, h_ExtPotTable, h_GenePotTable );
 
                      CPot[ko][jo][io] =   PotWeighting     *CPot[ko][jo][io]
                                         + PotWeighting_IntT*CPot_IntT;

--- a/src/TestProblem/Hydro/Plummer/ExtPot_Plummer.cpp
+++ b/src/TestProblem/Hydro/Plummer/ExtPot_Plummer.cpp
@@ -68,13 +68,14 @@ void SetExtPotAuxArray_Plummer( double AuxArray_Flt[], int AuxArray_Int[] )
 //                                        EXT_POT_USAGE_SUB_TINT: like SUB but for temporal interpolation
 //                                    --> This parameter is useless in most cases
 //                PotTable          : 3D potential table used by EXT_POT_TABLE
+//                GenePotTable      : Array of pointers for general potential table
 //
 // Return      :  External potential at (x,y,z,Time)
 //-----------------------------------------------------------------------------------------
 GPU_DEVICE_NOINLINE
 static real ExtPot_Plummer( const double x, const double y, const double z, const double Time,
                             const double UserArray_Flt[], const int UserArray_Int[],
-                            const ExtPotUsage_t Usage, const real PotTable[] )
+                            const ExtPotUsage_t Usage, const real PotTable[], void **GenePotTable )
 {
 
 // potential = -G*M/(r^2+R0^2)^(1/2)

--- a/src/TestProblem/Hydro/Plummer/ExtPot_Plummer.cpp
+++ b/src/TestProblem/Hydro/Plummer/ExtPot_Plummer.cpp
@@ -68,7 +68,7 @@ void SetExtPotAuxArray_Plummer( double AuxArray_Flt[], int AuxArray_Int[] )
 //                                        EXT_POT_USAGE_SUB_TINT: like SUB but for temporal interpolation
 //                                    --> This parameter is useless in most cases
 //                PotTable          : 3D potential table used by EXT_POT_TABLE
-//                GenePotTable      : Array of pointers for general potential table
+//                GenePotTable      : Array of pointers for general potential tables
 //
 // Return      :  External potential at (x,y,z,Time)
 //-----------------------------------------------------------------------------------------


### PR DESCRIPTION
- Add one `void** GenePotTable` argument to all `ExtPot_*` functions for general potential table.
- The size of `d_GenePotTable` and `h_GenePotTable`, `6 * sizeof(void*)`,  are hard coding in `Init_MemAllocate_PoissonGravity()` and `CUAPI_MemAllocate_PoissonGravity()`.