### PR TITLE
Update the CCSN test problem

### DIFF
--- a/example/test_problem/Hydro/CCSN/Input__TestProb.Lightbulb
+++ b/example/test_problem/Hydro/CCSN/Input__TestProb.Lightbulb
@@ -20,6 +20,6 @@ CCSN_Eint_Mode   1                                 # Mode of obtaining internal 
                                                    #   2=Pres Mode: Eint(dens, pres, [Ye]) )
 
 CCSN_MaxRefine_RadFac  0.15                        # factor that determines the maximum refinement level based on distance from the box center  [0.15]
-CCSN_LB_TimeFac        0.10                        # factor that scales the dt constrained by lightbulb scheme
+CCSN_LB_TimeFac        0.10                        # factor that scales the dt constrained by lightbulb scheme  [0.1]
 
-CCSN_Is_PostBounce     1                           # boolean that indicates whether core bounce have occurred
+CCSN_Is_PostBounce     1                           # boolean that indicates whether core bounce have occurred   [0]

--- a/example/test_problem/Hydro/CCSN/Input__TestProb.Lightbulb
+++ b/example/test_problem/Hydro/CCSN/Input__TestProb.Lightbulb
@@ -21,3 +21,5 @@ CCSN_Eint_Mode   1                                 # Mode of obtaining internal 
 
 CCSN_MaxRefine_RadFac  0.15                        # factor that determines the maximum refinement level based on distance from the box center  [0.15]
 CCSN_LB_TimeFac        0.10                        # factor that scales the dt constrained by lightbulb scheme
+
+CCSN_Is_PostBounce     1                           # boolean that indicates whether core bounce have occurred

--- a/example/test_problem/Hydro/CCSN/Input__TestProb.Lightbulb
+++ b/example/test_problem/Hydro/CCSN/Input__TestProb.Lightbulb
@@ -22,4 +22,4 @@ CCSN_Eint_Mode   1                                 # Mode of obtaining internal 
 CCSN_MaxRefine_RadFac  0.15                        # factor that determines the maximum refinement level based on distance from the box center  [0.15]
 CCSN_LB_TimeFac        0.10                        # factor that scales the dt constrained by lightbulb scheme  [0.1]
 
-CCSN_Is_PostBounce     1                           # boolean that indicates whether core bounce have occurred   [0]
+CCSN_Is_PostBounce     1                           # boolean that indicates whether core bounce has occurred   [0]

--- a/example/test_problem/Hydro/CCSN/Input__TestProb.PostBounce
+++ b/example/test_problem/Hydro/CCSN/Input__TestProb.PostBounce
@@ -19,4 +19,4 @@ CCSN_Eint_Mode   1                                 # Mode of obtaining internal 
                                                    # ( 1=Temp Mode: Eint(dens, temp, [Ye])
                                                    #   2=Pres Mode: Eint(dens, pres, [Ye]) )
 
-CCSN_Is_PostBounce     1                           # boolean that indicates whether core bounce have occurred  [0]
+CCSN_Is_PostBounce     1                           # boolean that indicates whether core bounce has occurred  [0]

--- a/example/test_problem/Hydro/CCSN/Input__TestProb.PostBounce
+++ b/example/test_problem/Hydro/CCSN/Input__TestProb.PostBounce
@@ -18,3 +18,5 @@ CCSN_GW_DT       1.0                               # output interval of GW signa
 CCSN_Eint_Mode   1                                 # Mode of obtaining internal energy in SetGridIC()  [2]
                                                    # ( 1=Temp Mode: Eint(dens, temp, [Ye])
                                                    #   2=Pres Mode: Eint(dens, pres, [Ye]) )
+
+CCSN_Is_PostBounce     1                           # boolean that indicates whether core bounce have occurred

--- a/example/test_problem/Hydro/CCSN/Input__TestProb.PostBounce
+++ b/example/test_problem/Hydro/CCSN/Input__TestProb.PostBounce
@@ -19,4 +19,4 @@ CCSN_Eint_Mode   1                                 # Mode of obtaining internal 
                                                    # ( 1=Temp Mode: Eint(dens, temp, [Ye])
                                                    #   2=Pres Mode: Eint(dens, pres, [Ye]) )
 
-CCSN_Is_PostBounce     1                           # boolean that indicates whether core bounce have occurred
+CCSN_Is_PostBounce     1                           # boolean that indicates whether core bounce have occurred  [0]

--- a/example/test_problem/Hydro/CCSN/README
+++ b/example/test_problem/Hydro/CCSN/README
@@ -4,7 +4,7 @@ Enable : MODEL=HYDRO, GRAVITY, GREP, [MHD]
 Disable: UNSPLIT_GRAVITY
 
 EOS    : EOS_GAMMA    (GREP migration test)
-         EOS_NUCLEAR  (Post bounce test)
+         EOS_NUCLEAR  (Post bounce test and Lightbulb test)
 
 Default setup:
 ========================================
@@ -23,6 +23,9 @@ Default setup:
 
 3. For Post bounce:
    --> MAX_LEVEL = 8
+
+4. For Lightbulb:
+   --> OPT__DT_USER = 1
 
 Note:
 ========================================

--- a/example/test_problem/Hydro/CCSN/README
+++ b/example/test_problem/Hydro/CCSN/README
@@ -72,5 +72,5 @@ Note:
                    runs with higher values have better performance, but consume more memory
 
 6. Additional Record files:
-   --> Record__CentralDens : maximum density in the simulation box
-   --> Record__QuadMom_2nd : second-order time derivative of mass quadrupole moments
+   --> Record__CentralQuant : quantites at the center (cell with highest density)
+   --> Record__QuadMom_2nd  : second-order time derivative of mass quadrupole moments

--- a/example/test_problem/Hydro/CCSN/README
+++ b/example/test_problem/Hydro/CCSN/README
@@ -71,6 +71,8 @@ Note:
    --> num_chunk : number of chunk for computing the vector potential sequentially
                    runs with higher values have better performance, but consume more memory
 
-6. Additional Record files:
+6. The threshold values in Input__Flag_Rho and Input__Flag_User must be in the code units
+
+7. Additional Record files:
    --> Record__CentralQuant : quantites at the center (cell with highest density)
    --> Record__QuadMom_2nd  : second-order time derivative of mass quadrupole moments

--- a/example/test_problem/Hydro/CCSN/clean.sh
+++ b/example/test_problem/Hydro/CCSN/clean.sh
@@ -3,4 +3,4 @@ rm -f Record__Note Record__Timing Record__TimeStep Record__PatchCount Record__Du
       Diag* BaseXYslice* BaseYZslice* BaseXZslice* BaseXline* BaseYline* BaseZline* BaseDiag* \
       PowerSpec_* Particle_* nohup.out Record__Performance Record__TimingMPI_* \
       Record__ParticleCount Record__User Patch_* Record__NCorrUnphy FailedPatchGroup* *.pyc Record__LoadBalance \
-      GRACKLE_INFO Record__DivB Record__CentralDens Record__QuadMom_2nd
+      GRACKLE_INFO Record__DivB Record__CentralQuant Record__QuadMom_2nd

--- a/example/test_problem/Hydro/CCSN/python_script/plot_rhoc_migrationtest.py
+++ b/example/test_problem/Hydro/CCSN/python_script/plot_rhoc_migrationtest.py
@@ -20,8 +20,8 @@ fn_flash = "../ReferenceSolution/MigrationTest/flash_1d.dat"
 t_flash, rhoc_flash = np.genfromtxt(fn_flash, unpack = True)
 
 # GAMER
-fn_gamer = "../Record__CentralDens"
-t_gamer, rhoc_gamer = np.genfromtxt(fn_gamer, usecols = [0, 2], unpack = True)
+fn_gamer = "../Record__CentralQuant"
+t_gamer, rhoc_gamer = np.genfromtxt(fn_gamer, usecols = [0, 5], unpack = True)
 
 
 ### plot the evolution of central density

--- a/example/test_problem/Hydro/CCSN/python_script/plot_rhoc_postbounce.py
+++ b/example/test_problem/Hydro/CCSN/python_script/plot_rhoc_postbounce.py
@@ -47,8 +47,8 @@ t_flash, rhoc_flash = np.genfromtxt(fn_flash, usecols = [0, 16], unpack = True)
 t_flash -= tb_flash
 
 ## GAMER
-fn_gamer = "../Record__CentralDens"
-t_gamer, rhoc_gamer = np.genfromtxt(fn_gamer, usecols = [0, 2], unpack = True)
+fn_gamer = "../Record__CentralQuant"
+t_gamer, rhoc_gamer = np.genfromtxt(fn_gamer, usecols = [0, 5], unpack = True)
 t_gamer += 0.015  # the IC is from the FLASH simulation at t_pb = 15 ms
 
 

--- a/src/TestProblem/Hydro/CCSN/Flag_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/Flag_CCSN.cpp
@@ -56,7 +56,7 @@ bool Flag_Lightbulb( const int i, const int j, const int k, const int lv, const 
 //    (2-a) density is larger than the threshold in Input__Flag_User
       if ( Rho[k][j][i] < Threshold[0] )   return false;
 
-//    (2-b) the cell with at son level (lv+1) is larger than the threshold
+//    (2-b) the cell width at son level (lv+1) is larger than the threshold
       const double Min_CellWidth = r * CCSN_MaxRefine_RadFac;
 
       Flag = ( 0.5 * dh ) > Min_CellWidth;

--- a/src/TestProblem/Hydro/CCSN/Flag_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/Flag_CCSN.cpp
@@ -1,0 +1,64 @@
+#include "GAMER.h"
+
+
+extern double CCSN_MaxRefine_RadFac;
+
+
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  Flag_Lightbulb
+// Description :  Check if the element (i,j,k) of the input data satisfies the user-defined flag criteria
+//
+// Note        :  1. Invoked by "Flag_Check" using the function pointer "Flag_User_Ptr"
+//                   --> The function pointer may be reset by various test problem initializers, in which case
+//                       this function will become useless
+//                2. Enabled by the runtime option "OPT__FLAG_USER"
+//                3. For lightbulb test problem
+//
+// Parameter   :  i,j,k       : Indices of the target element in the patch ptr[ amr->FluSg[lv] ][lv][PID]
+//                lv          : Refinement level of the target patch
+//                PID         : ID of the target patch
+//                Threshold   : User-provided threshold for the flag operation, which is loaded from the
+//                              file "Input__Flag_User"
+//                              In order of radius_min, radius_max, threshold_dens
+//
+// Return      :  "true"  if the flag criteria are satisfied
+//                "false" if the flag criteria are not satisfied
+//-------------------------------------------------------------------------------------------------------
+bool Flag_Lightbulb( const int i, const int j, const int k, const int lv, const int PID, const double *Threshold )
+{
+
+   bool Flag = false;
+
+   const double dh        = amr->dh[lv];
+   const double Center[3] = { amr->BoxCenter[0], amr->BoxCenter[1], amr->BoxCenter[2] };
+   const double Pos   [3] = { amr->patch[0][lv][PID]->EdgeL[0] + (i+0.5)*dh,
+                              amr->patch[0][lv][PID]->EdgeL[1] + (j+0.5)*dh,
+                              amr->patch[0][lv][PID]->EdgeL[2] + (k+0.5)*dh  };
+
+   const double dx = Center[0] - Pos[0];
+   const double dy = Center[1] - Pos[1];
+   const double dz = Center[2] - Pos[2];
+   const double r  = sqrt(  SQR( dx ) + SQR( dy ) + SQR( dz )  );
+
+   const real (*Rho )[PS1][PS1] = amr->patch[ amr->FluSg[lv] ][lv][PID]->fluid[DENS];
+
+
+// TODO: fine-tune the criteria
+// always allow the highest level can be reached in the region with r < 30 km
+   if ( r * UNIT_L < 3e6 )
+   {
+      Flag = true;
+   }
+
+   else
+   {
+//    if density is larger than the threshold (equivalent to Input__Flag_Rho)
+//    and the cell width at lv+1 is larger than the threshold `r * CCSN_MaxRefine_RadFac` (equivalent to Flag_Region)
+      if (  ( Rho[k][j][i] > Threshold[0] )  &&  ( 0.5 * dh > r * CCSN_MaxRefine_RadFac )  )   Flag = true;
+   }
+
+
+   return Flag;
+
+} // FUNCTION : Flag_Lightbulb

--- a/src/TestProblem/Hydro/CCSN/Flag_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/Flag_CCSN.cpp
@@ -45,7 +45,7 @@ bool Flag_Lightbulb( const int i, const int j, const int k, const int lv, const 
 
 
 // TODO: fine-tune the criteria
-// always allow the highest level can be reached in the region with r < 30 km
+// (1) always refined to highest level in the region with r < 30 km
    if ( r * UNIT_L < 3e6 )
    {
       Flag = true;
@@ -53,9 +53,13 @@ bool Flag_Lightbulb( const int i, const int j, const int k, const int lv, const 
 
    else
    {
-//    if density is larger than the threshold (equivalent to Input__Flag_Rho)
-//    and the cell width at lv+1 is larger than the threshold `r * CCSN_MaxRefine_RadFac` (equivalent to Flag_Region)
-      if (  ( Rho[k][j][i] > Threshold[0] )  &&  ( 0.5 * dh > r * CCSN_MaxRefine_RadFac )  )   Flag = true;
+//    (2-a) density is larger than the threshold in Input__Flag_User
+      if ( Rho[k][j][i] < Threshold[0] )   return false;
+
+//    (2-b) the cell with at son level (lv+1) is larger than the threshold
+      const double Min_CellWidth = r * CCSN_MaxRefine_RadFac;
+
+      Flag = ( 0.5 * dh ) > Min_CellWidth;
    }
 
 

--- a/src/TestProblem/Hydro/CCSN/Init_TestProb_Hydro_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/Init_TestProb_Hydro_CCSN.cpp
@@ -181,6 +181,13 @@ void SetParameter()
          Aux_Error( ERROR_INFO, "Temperature mode for initializing grids is not supported in Migration Test yet!!\n" );
    }
 
+// do not need to check core bounce in the migration test
+   if ( CCSN_Prob == Migration_Test )
+      CCSN_Is_PostBounce = 1;
+
+   if (  ( CCSN_Is_PostBounce == 0 )  &&  ( CCSN_Prob == Post_Bounce )  )
+      Aux_Error( ERROR_INFO, "Incorrect parameter %s = %d !!\n", "CCSN_Is_PostBounce", CCSN_Is_PostBounce );
+
 
 // (2) set the problem-specific derived parameters
 
@@ -217,9 +224,10 @@ void SetParameter()
       Aux_Message( stdout, "  output GW signals                       = %d\n",      CCSN_GW_OUTPUT        );
       Aux_Message( stdout, "  sampling interval of GW signals         = %13.7e\n",  CCSN_GW_DT            );
       Aux_Message( stdout, "  mode for obtaining internal energy      = %d\n",      CCSN_Eint_Mode        );
+      if ( CCSN_Prob != Migration_Test ) {
       Aux_Message( stdout, "  radial factor for maximum refine level  = %13.7e\n",  CCSN_MaxRefine_RadFac );
       Aux_Message( stdout, "  scaling factor for lightbulb dt         = %13.7e\n",  CCSN_LB_TimeFac       );
-      Aux_Message( stdout, "  has core bounce occurred                = %d\n",      CCSN_Is_PostBounce    );
+      Aux_Message( stdout, "  has core bounce occurred                = %d\n",      CCSN_Is_PostBounce    ); }
       Aux_Message( stdout, "=============================================================================\n" );
    }
 
@@ -589,7 +597,7 @@ void Record_CCSN()
       if ( CCSN_Is_PostBounce )
       {
 //       dump the bounce time in standard output
-         if ( MPI_Rank == 0 )   Aux_Message( stdout, "Bounce time = %13.7e !!\n", Time[0] * UNIT_T );
+         if ( MPI_Rank == 0 )   Aux_Message( stdout, "Bounce time = %13.7e seconds !!\n", Time[0] * UNIT_T );
 
 //       disable the deleptonization scheme, and enable the lightbulb scheme
          SrcTerms.Deleptonization = false;

--- a/src/TestProblem/Hydro/CCSN/Init_TestProb_Hydro_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/Init_TestProb_Hydro_CCSN.cpp
@@ -482,7 +482,7 @@ void SetBFieldIC_Suwa2007( real magnetic[], const double x, const double y, cons
                            const int lv, double AuxArray[] )
 {
 
-   const double  BoxCenter[3] = { amr->BoxCenter[0], amr->BoxCenter[1], amr->BoxCenter[2] };
+   const double BoxCenter[3] = { amr->BoxCenter[0], amr->BoxCenter[1], amr->BoxCenter[2] };
 
    const double x0 = x - BoxCenter[0];
    const double y0 = y - BoxCenter[1];
@@ -537,7 +537,7 @@ void Load_IC_Prof_CCSN()
 
 //-------------------------------------------------------------------------------------------------------
 // Function    :  Record_CCSN
-// Description :  Interface for invoking multiple record functions
+// Description :  Interface for invoking several functions for recording data and detecting core bounce
 //-------------------------------------------------------------------------------------------------------
 void Record_CCSN()
 {
@@ -560,7 +560,7 @@ void Record_CCSN()
 
          else
          {
-            DumpTime_CCSN = ( int(Time[0]/CCSN_GW_DT) + 1.0 )*CCSN_GW_DT;
+            DumpTime_CCSN = (  int( Time[0] / CCSN_GW_DT ) + 1.0  ) * CCSN_GW_DT;
 
 //          be careful about round-off errors
             if (   (  DumpTime_CCSN <= Time[0]  )                                         ||
@@ -588,7 +588,7 @@ void Record_CCSN()
       if ( CCSN_Is_PostBounce )
       {
 //       dump the bounce time in standard output
-         if ( MPI_Rank == 0 )   Aux_Message( stdout, "Bounce time = %13.7e !!\n", Time[0]*UNIT_T );
+         if ( MPI_Rank == 0 )   Aux_Message( stdout, "Bounce time = %13.7e !!\n", Time[0] * UNIT_T );
 
 //       disable the deleptonization scheme, and enable the lightbulb scheme
          SrcTerms.Deleptonization = false;
@@ -625,7 +625,7 @@ double Mis_GetTimeStep_CCSN( const int lv, const double dTime_dt )
 
 
 //-------------------------------------------------------------------------------------------------------
-// Function    :  Flag_User_CCSN
+// Function    :  Flag_CCSN
 // Description :  Check if the element (i,j,k) of the input data satisfies the user-defined flag criteria
 //
 // Note        :  1. Invoked by "Flag_Check" using the function pointer "Flag_User_Ptr"
@@ -643,7 +643,7 @@ double Mis_GetTimeStep_CCSN( const int lv, const double dTime_dt )
 // Return      :  "true"  if the flag criteria are satisfied
 //                "false" if the flag criteria are not satisfied
 //-------------------------------------------------------------------------------------------------------
-bool Flag_User_CCSN( const int i, const int j, const int k, const int lv, const int PID, const double *Threshold )
+bool Flag_CCSN( const int i, const int j, const int k, const int lv, const int PID, const double *Threshold )
 {
 
    bool Flag = false;
@@ -678,7 +678,7 @@ bool Flag_User_CCSN( const int i, const int j, const int k, const int lv, const 
 
    return Flag;
 
-} // FUNCTION : Flag_User_CCSN
+} // FUNCTION : Flag_CCSN
 
 
 
@@ -728,18 +728,19 @@ void Init_TestProb_Hydro_CCSN()
    if ( OPT__INIT != INIT_BY_RESTART )   Load_IC_Prof_CCSN();
 
 // set the function pointers of various problem-specific routines
-   Init_Function_User_Ptr         = SetGridIC;
+   Init_Function_User_Ptr   = SetGridIC;
+   Flag_User_Ptr            = Flag_CCSN;
+   Aux_Record_User_Ptr      = Record_CCSN;
+   End_User_Ptr             = End_CCSN;
+   Mis_GetTimeStep_User_Ptr = Mis_GetTimeStep_CCSN;
+
 #  ifdef MHD
    switch ( CCSN_Mag )
    {
-      case Liu2008  : Init_Function_BField_User_Ptr  = SetBFieldIC_Liu2008;    break;
-      case Suwa2007 : Init_Function_BField_User_Ptr  = SetBFieldIC_Suwa2007;   break;
+      case Liu2008  : Init_Function_BField_User_Ptr = SetBFieldIC_Liu2008;    break;
+      case Suwa2007 : Init_Function_BField_User_Ptr = SetBFieldIC_Suwa2007;   break;
    }
-#  endif
-   Flag_User_Ptr                  = Flag_User_CCSN;
-   Aux_Record_User_Ptr            = Record_CCSN;
-   End_User_Ptr                   = End_CCSN;
-   Mis_GetTimeStep_User_Ptr       = Mis_GetTimeStep_CCSN;
+#  endif // #if MHD
 #  endif // #if ( MODEL == HYDRO )
 
 

--- a/src/TestProblem/Hydro/CCSN/Init_TestProb_Hydro_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/Init_TestProb_Hydro_CCSN.cpp
@@ -54,10 +54,10 @@ static double     CCSN_MaxRefine_RadFac;           // factor that determines the
 
 
 // problem-specific function prototypes
-void Record_CCSN_CentralDens();
-void Record_CCSN_GWSignal();
-void Detect_CoreBounce();
-void Mis_GetTimeStep_User_Lightbulb( const int lv, const double dTime_dt );
+void   Record_CCSN_CentralDens();
+void   Record_CCSN_GWSignal();
+void   Detect_CoreBounce();
+double Mis_GetTimeStep_Lightbulb( const int lv, const double dTime_dt );
 
 
 
@@ -179,9 +179,6 @@ void SetParameter()
       if ( CCSN_Prob == Migration_Test )
          Aux_Error( ERROR_INFO, "Temperature mode for initializing grids is not supported in Migration Test yet!!\n" );
    }
-
-   if (  OPT__DT_USER  &&  ( SrcTerms.Lightbulb == 0 )  )
-      Aux_Error( ERROR_INFO, "OPT__DT_USER only supports SRC_LIGHTBULB == 1 !!\n" );
 
 
 // (2) set the problem-specific derived parameters
@@ -609,6 +606,25 @@ void Record_CCSN()
 
 
 //-------------------------------------------------------------------------------------------------------
+// Function    :  Mis_GetTimeStep_CCSN
+// Description :  Interface for invoking several functions for estimating the evolution time-step
+//-------------------------------------------------------------------------------------------------------
+double Mis_GetTimeStep_CCSN( const int lv, const double dTime_dt )
+{
+
+   double dt_CCSN = HUGE_NUMBER;
+
+   if ( SrcTerms.Lightbulb )
+      dt_CCSN = MIN(  dt_CCSN, Mis_GetTimeStep_Lightbulb( lv, dTime_dt )  );
+
+
+   return dt_CCSN;
+
+} // FUNCTION : Mis_GetTimeStep_CCSN()
+
+
+
+//-------------------------------------------------------------------------------------------------------
 // Function    :  Flag_User_CCSN
 // Description :  Check if the element (i,j,k) of the input data satisfies the user-defined flag criteria
 //
@@ -723,12 +739,7 @@ void Init_TestProb_Hydro_CCSN()
    Flag_User_Ptr                  = Flag_User_CCSN;
    Aux_Record_User_Ptr            = Record_CCSN;
    End_User_Ptr                   = End_CCSN;
-
-// estimate the evolution time-step constrained by the lightbulb source term
-   if ( SrcTerms.Lightbulb )
-   {
-      Mis_GetTimeStep_User_Ptr    = Mis_GetTimeStep_User_Lightbulb;  // option: OPT__DT_USER;
-   }
+   Mis_GetTimeStep_User_Ptr       = Mis_GetTimeStep_CCSN;
 #  endif // #if ( MODEL == HYDRO )
 
 

--- a/src/TestProblem/Hydro/CCSN/Init_TestProb_Hydro_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/Init_TestProb_Hydro_CCSN.cpp
@@ -54,7 +54,7 @@ static double     CCSN_MaxRefine_RadFac;           // factor that determines the
 
 
 // problem-specific function prototypes
-void   Record_CCSN_CentralDens();
+void   Record_CCSN_CentralQuant();
 void   Record_CCSN_GWSignal();
 void   Detect_CoreBounce();
 double Mis_GetTimeStep_Lightbulb( const int lv, const double dTime_dt );
@@ -542,8 +542,8 @@ void Load_IC_Prof_CCSN()
 void Record_CCSN()
 {
 
-// (1) maximum density
-   Record_CCSN_CentralDens();
+// (1) record quantities at the center
+   Record_CCSN_CentralQuant();
 
 
 // (2) GW signal

--- a/src/TestProblem/Hydro/CCSN/Init_TestProb_Hydro_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/Init_TestProb_Hydro_CCSN.cpp
@@ -89,6 +89,8 @@ void Validate()
    if ( !OPT__UNIT )
       Aux_Error( ERROR_INFO, "OPT__UNIT must be enabled !!\n" );
 
+   if ( !OPT__RECORD_USER )
+      Aux_Error( ERROR_INFO, "OPT__RECORD_USER must be enabled !!\n" );
 
    if ( MPI_Rank == 0 )    Aux_Message( stdout, "   Validating test problem %d ... done\n", TESTPROB_ID );
 

--- a/src/TestProblem/Hydro/CCSN/Init_TestProb_Hydro_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/Init_TestProb_Hydro_CCSN.cpp
@@ -49,7 +49,7 @@ static int        CCSN_Eint_Mode;                  // Mode of obtaining internal
        double     CCSN_MaxRefine_RadFac;           // factor that determines the maximum refinement level based on distance from the box center
        double     CCSN_LB_TimeFac;                 // factor that scales the dt constrained by lightbulb scheme
 
-       bool       CCSN_Is_PostBounce = false;      // boolean that indicates whether core bounce have occurred
+       bool       CCSN_Is_PostBounce = false;      // boolean that indicates whether core bounce has occurred
 // =======================================================================================
 
 
@@ -624,7 +624,11 @@ double Mis_GetTimeStep_CCSN( const int lv, const double dTime_dt )
    double dt_CCSN = HUGE_NUMBER;
 
    if ( SrcTerms.Lightbulb )
-      dt_CCSN = MIN(  dt_CCSN, Mis_GetTimeStep_Lightbulb( lv, dTime_dt )  );
+   {
+      const double dt_LB = Mis_GetTimeStep_Lightbulb( lv, dTime_dt );
+
+      dt_CCSN = fmin( dt_CCSN, dt_LB );
+   }
 
 
    return dt_CCSN;

--- a/src/TestProblem/Hydro/CCSN/Record_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/Record_CCSN.cpp
@@ -375,8 +375,8 @@ void Detect_CoreBounce()
    const int NT = 1;
 #  endif
 
-   double MaxEntr = -__DBL_MAX__;
-   double OMP_MaxEntr[NT];
+   real MaxEntr = -HUGE_NUMBER;
+   real OMP_MaxEntr[NT];
 
 
 #  pragma omp parallel
@@ -388,7 +388,7 @@ void Detect_CoreBounce()
 #     endif
 
 //    initialize arrays
-      OMP_MaxEntr[TID] = -__DBL_MAX__;
+      OMP_MaxEntr[TID] = -HUGE_NUMBER;
 
       for (int lv=0; lv<NLEVEL; lv++)
       {
@@ -424,7 +424,7 @@ void Detect_CoreBounce()
                                       false, NULL_REAL, Emag, EoS_DensEint2Entr_CPUPtr,
                                       EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
 
-               OMP_MaxEntr[TID] = MAX( OMP_MaxEntr[TID], (double)Entr );
+               OMP_MaxEntr[TID] = FMAX( OMP_MaxEntr[TID], Entr );
 
             }}} // i,j,k
          } // for (int PID=0; PID<amr->NPatchComma[lv][1]; PID++)
@@ -434,12 +434,12 @@ void Detect_CoreBounce()
 
 // find the maximum over all OpenMP threads
    for (int TID=0; TID<NT; TID++)
-      MaxEntr = MAX( MaxEntr, OMP_MaxEntr[TID] );
+      MaxEntr = FMAX( MaxEntr, OMP_MaxEntr[TID] );
 
 
 // collect data from all ranks
 #  ifndef SERIAL
-   MPI_Allreduce( MPI_IN_PLACE, &MaxEntr, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD );
+   MPI_Allreduce( MPI_IN_PLACE, &MaxEntr, 1, MPI_GAMER_REAL, MPI_MAX, MPI_COMM_WORLD );
 #  endif // ifndef SERIAL
 
 

--- a/src/TestProblem/Hydro/CCSN/Record_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/Record_CCSN.cpp
@@ -138,8 +138,8 @@ void Record_CCSN_CentralQuant()
          {
              FILE *file_cent_quant = fopen( filename_central_quant, "w" );
              fprintf( file_cent_quant, "#%14s %12s %16s %16s %16s %16s %16s\n",
-                                       "Time [sec]", "Step", "PosX [cm]", "PosY [cm]", "PosZ [cm]",
-                                       "Dens [g/cm^3]", "Ye" );
+                                       "1_Time [sec]", "2_Step", "3_PosX [cm]", "4_PosY [cm]", "5_PosZ [cm]",
+                                       "6_Dens [g/cm^3]", "7_Ye" );
              fclose( file_cent_quant );
          }
 

--- a/src/TestProblem/Hydro/CCSN/Record_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/Record_CCSN.cpp
@@ -214,7 +214,7 @@ void Record_CCSN_GWSignal()
                const double dx = x - BoxCenter[0];
                const double dy = y - BoxCenter[1];
                const double dz = z - BoxCenter[2];
-               const double r = sqrt( SQR(dx) + SQR(dy) + SQR(dz) );
+               const double r  = sqrt(  SQR( dx ) + SQR( dy ) + SQR( dz )  );
 
                const double dens  = amr->patch[ amr->FluSg[lv] ][lv][PID]->fluid[DENS][k][j][i];
                const double momx  = amr->patch[ amr->FluSg[lv] ][lv][PID]->fluid[MOMX][k][j][i];

--- a/src/TestProblem/Hydro/CCSN/dtSolver_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/dtSolver_CCSN.cpp
@@ -1,9 +1,6 @@
 #include "GAMER.h"
 #include "NuclearEoS.h"
 
-#if ( MODEL == HYDRO )
-
-
 
 extern double CCSN_LB_TimeFac;
 
@@ -160,7 +157,3 @@ double Mis_GetTimeStep_Lightbulb( const int lv, const double dTime_dt )
    return dt_LB;
 
 } // FUNCTION : Mis_GetTimeStep_Lightbulb
-
-
-
-#endif // if ( MODEL == HYDRO )

--- a/src/TestProblem/Hydro/CCSN/dtSolver_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/dtSolver_CCSN.cpp
@@ -5,15 +5,12 @@
 
 
 
-// declare as static so that other functions cannot invoke it directly and must use the function pointer
-double Mis_GetTimeStep_User_Lightbulb( const int lv, const double dTime_dt );
-
 extern double CCSN_LB_TimeFac;
 
 
 
 //-------------------------------------------------------------------------------------------------------
-// Function    :  Mis_GetTimeStep_User_Lightbulb
+// Function    :  Mis_GetTimeStep_Lightbulb
 // Description :  estimate the evolution time-step constrained by the lightbulb source term
 //
 // Note        :  1. This function should be applied to both physical and comoving coordinates and always
@@ -31,7 +28,7 @@ extern double CCSN_LB_TimeFac;
 //
 // Return      :  dt
 //-------------------------------------------------------------------------------------------------------
-double Mis_GetTimeStep_User_Lightbulb( const int lv, const double dTime_dt )
+double Mis_GetTimeStep_Lightbulb( const int lv, const double dTime_dt )
 {
 
    const double BoxCenter[3] = { amr->BoxCenter[0], amr->BoxCenter[1], amr->BoxCenter[2] };
@@ -162,7 +159,7 @@ double Mis_GetTimeStep_User_Lightbulb( const int lv, const double dTime_dt )
 
    return dt_LB;
 
-} // FUNCTION : Mis_GetTimeStep_User_Lightbulb
+} // FUNCTION : Mis_GetTimeStep_Lightbulb
 
 
 


### PR DESCRIPTION
- Support detecting core bounce
  - disable deleptonization scheme, and enable lightbulb scheme
  - record the bounce time at standard output
  - dump the HDF5 data at core bounce
- Generalize the `Mis_GetTimeStep_User_Ptr()` so that the `Mis_GetTimeStep_Lightbulb()` is applied after core bounces
- Add variables refer to the column index of Ye, temperature, and entropy in IC
- Support output serveral quantities at the center
  - currently, only Ye is added