### PR TITLE
GREP Optimization

### DIFF
--- a/example/test_problem/Hydro/CCSN/Input__Parameter.Lightbulb
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.Lightbulb
@@ -188,6 +188,7 @@ GREP_MAXRADIUS               -1.0            # maximum radius in the radial prof
                                              # (<=0=distance of the farthest vertex to the center)
 GREP_MINBINSIZE              -1.0            # minimum bin size                                             [-1.0]
                                              # (<=0=use amr->dh[MAX_LEVEL])
+GREP_OPT_FIXUP                0              # fix up the profiles on the father level at previous time     [0]
 
 
 # initialization

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.Lightbulb
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.Lightbulb
@@ -178,17 +178,17 @@ SRC_GPU_NPGROUP              -1           # number of patch groups sent into the
 
 
 # GREP
-GREP_CENTER_METHOD            1              # center of radial profile                                     [1]
-                                             # (1=box center)
-GREP_MAXITER                  1000           # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
-GREP_LOGBIN                   1              # log/linear bins                                              [true]
-                                             # (true=logarithmic, false=linear)
-GREP_LOGBINRATIO              1.0025         # ratio of adjacent log bins                                   [1.25]
-GREP_MAXRADIUS               -1.0            # maximum radius in the radial profile                         [-1.0]
-                                             # (<=0=distance of the farthest vertex to the center)
-GREP_MINBINSIZE              -1.0            # minimum bin size                                             [-1.0]
-                                             # (<=0=use amr->dh[MAX_LEVEL])
-GREP_OPT_FIXUP                0              # fix up the profiles on the father level at previous time     [0]
+GREP_CENTER_METHOD            1           # center of radial profile                                     [1]
+                                          # (1=box center)
+GREP_MAXITER                  1000        # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
+GREP_LOGBIN                   1           # log/linear bins                                              [true]
+                                          # (true=logarithmic, false=linear)
+GREP_LOGBINRATIO              1.0025      # ratio of adjacent log bins                                   [1.25]
+GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile                         [-1.0]
+                                          # (<=0=distance of the farthest vertex to the center)
+GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
+                                          # (<=0=use amr->dh[MAX_LEVEL])
+GREP_OPT_FIXUP                1           # fix up the profiles after grid allocation/deallocation       [1]
 
 
 # initialization

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.MigrationTest
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.MigrationTest
@@ -180,7 +180,7 @@ GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile
                                           # (<=0=distance of the farthest vertex to the center)
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
                                           # (<=0=use amr->dh[MAX_LEVEL])
-GREP_OPT_FIXUP                0           # fix up the profiles on the father level at previous time     [0]
+GREP_OPT_FIXUP                1           # fix up the profiles after grid allocation/deallocation       [1]
 
 
 # initialization

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.MigrationTest
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.MigrationTest
@@ -180,6 +180,7 @@ GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile
                                           # (<=0=distance of the farthest vertex to the center)
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
                                           # (<=0=use amr->dh[MAX_LEVEL])
+GREP_OPT_FIXUP                0           # fix up the profiles on the father level at previous time     [0]
 
 
 # initialization

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.PostBounce
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.PostBounce
@@ -169,17 +169,17 @@ OPT__EXT_POT                  3           # add external potential    (0=off, 1=
 
 
 # GREP
-GREP_CENTER_METHOD            1              # center of radial profile                                     [1]
-                                             # (1=box center)
-GREP_MAXITER                  1000           # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
-GREP_LOGBIN                   1              # log/linear bins                                              [true]
-                                             # (true=logarithmic, false=linear)
-GREP_LOGBINRATIO              1.0025         # ratio of adjacent log bins                                   [1.25]
-GREP_MAXRADIUS               -1.0            # maximum radius in the radial profile                         [-1.0]
-                                             # (<=0=distance of the farthest vertex to the center)
-GREP_MINBINSIZE              -1.0            # minimum bin size                                             [-1.0]
-                                             # (<=0=use amr->dh[MAX_LEVEL])
-GREP_OPT_FIXUP                0              # fix up the profiles on the father level at previous time     [0]
+GREP_CENTER_METHOD            1           # center of radial profile                                     [1]
+                                          # (1=box center)
+GREP_MAXITER                  1000        # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
+GREP_LOGBIN                   1           # log/linear bins                                              [true]
+                                          # (true=logarithmic, false=linear)
+GREP_LOGBINRATIO              1.0025      # ratio of adjacent log bins                                   [1.25]
+GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile                         [-1.0]
+                                          # (<=0=distance of the farthest vertex to the center)
+GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
+                                          # (<=0=use amr->dh[MAX_LEVEL])
+GREP_OPT_FIXUP                1           # fix up the profiles after grid allocation/deallocation       [1]
 
 
 # initialization

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.PostBounce
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.PostBounce
@@ -179,6 +179,7 @@ GREP_MAXRADIUS               -1.0            # maximum radius in the radial prof
                                              # (<=0=distance of the farthest vertex to the center)
 GREP_MINBINSIZE              -1.0            # minimum bin size                                             [-1.0]
                                              # (<=0=use amr->dh[MAX_LEVEL])
+GREP_OPT_FIXUP                0              # fix up the profiles on the father level at previous time     [0]
 
 
 # initialization

--- a/example/test_problem/Template/Input__Parameter
+++ b/example/test_problem/Template/Input__Parameter
@@ -279,7 +279,7 @@ GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile
                                           # (<=0=distance of the farthest vertex to the center)
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
                                           # (<=0=use amr->dh[MAX_LEVEL])
-GREP_OPT_FIXUP                0           # fix up the profiles on the father level at previous time     [0]
+GREP_OPT_FIXUP                1           # fix up the profiles after grid allocation/deallocation       [1]
 
 
 # initialization

--- a/example/test_problem/Template/Input__Parameter
+++ b/example/test_problem/Template/Input__Parameter
@@ -279,6 +279,7 @@ GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile
                                           # (<=0=distance of the farthest vertex to the center)
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
                                           # (<=0=use amr->dh[MAX_LEVEL])
+GREP_OPT_FIXUP                0           # fix up the profiles on the father level at previous time     [0]
 
 
 # initialization

--- a/include/Global.h
+++ b/include/Global.h
@@ -277,6 +277,7 @@ extern bool   GREP_LOGBIN;
 extern double GREP_LOGBINRATIO;
 extern double GREP_MAXRADIUS;
 extern double GREP_MINBINSIZE;
+extern bool   GREP_OPT_FIXUP;
 
 
 // (2-11) source terms

--- a/include/HDF5_Typedef.h
+++ b/include/HDF5_Typedef.h
@@ -560,6 +560,7 @@ struct InputPara_t
    double GREP_LogBinRatio;
    double GREP_MaxRadius;
    double GREP_MinBinSize;
+   int    GREP_Opt_FixUp;
 #  endif // #ifdef GRAVITY
 
 // source terms

--- a/src/Auxiliary/Aux_TakeNote.cpp
+++ b/src/Auxiliary/Aux_TakeNote.cpp
@@ -1138,7 +1138,8 @@ void Aux_TakeNote()
       fprintf( Note, "GREP_LOGBIN                     %d\n",      GREP_LOGBIN             );
       fprintf( Note, "GREP_LOGBINRATIO                %13.7e\n",  GREP_LOGBINRATIO        );
       fprintf( Note, "GREP_MAXRADIUS                  %13.7e\n",  GREP_MAXRADIUS          );
-      fprintf( Note, "GREP_MINBINSIZE                 %13.7e\n",  GREP_MINBINSIZE         ); }
+      fprintf( Note, "GREP_MINBINSIZE                 %13.7e\n",  GREP_MINBINSIZE         );
+      fprintf( Note, "GREP_OPT_FIXUP                  %d\n",      GREP_OPT_FIXUP          ); }
       fprintf( Note, "AveDensity_Init                 %13.7e\n",  AveDensity_Init         );
       fprintf( Note, "***********************************************************************************\n" );
       fprintf( Note, "\n\n");

--- a/src/Init/Init_ByRestart_HDF5.cpp
+++ b/src/Init/Init_ByRestart_HDF5.cpp
@@ -1979,6 +1979,7 @@ void Check_InputPara( const char *FileName, const int FormatVersion )
    LoadField( "GREP_LogBinRatio",        &RS.GREP_LogBinRatio,        SID, TID, NonFatal, &RT.GREP_LogBinRatio,         1, NonFatal );
    LoadField( "GREP_MaxRadius",          &RS.GREP_MaxRadius,          SID, TID, NonFatal, &RT.GREP_MaxRadius,           1, NonFatal );
    LoadField( "GREP_MinBinSize",         &RS.GREP_MinBinSize,         SID, TID, NonFatal, &RT.GREP_MinBinSize,          1, NonFatal );
+   LoadField( "GREP_Opt_FixUp",          &RS.GREP_Opt_FixUp,          SID, TID, NonFatal, &RT.GREP_Opt_FixUp,           1, NonFatal );
 #  endif // #ifdef GRAVITY
 
 // source terms

--- a/src/Init/Init_Load_Parameter.cpp
+++ b/src/Init/Init_Load_Parameter.cpp
@@ -343,6 +343,7 @@ void Init_Load_Parameter()
    ReadPara->Add( "GREP_LOGBINRATIO",          &GREP_LOGBINRATIO,                 1.25,            1.0,            NoMax_double  );
    ReadPara->Add( "GREP_MAXRADIUS",            &GREP_MAXRADIUS,                  -1.0,             NoMin_double,   NoMax_double  );
    ReadPara->Add( "GREP_MINBINSIZE",           &GREP_MINBINSIZE,                 -1.0,             NoMin_double,   NoMax_double  );
+   ReadPara->Add( "GREP_OPT_FIXUP",            &GREP_OPT_FIXUP,                   false,           Useless_bool,   Useless_bool  );
 #  endif // #ifdef GRAVITY
 
 

--- a/src/Init/Init_Load_Parameter.cpp
+++ b/src/Init/Init_Load_Parameter.cpp
@@ -343,7 +343,7 @@ void Init_Load_Parameter()
    ReadPara->Add( "GREP_LOGBINRATIO",          &GREP_LOGBINRATIO,                 1.25,            1.0,            NoMax_double  );
    ReadPara->Add( "GREP_MAXRADIUS",            &GREP_MAXRADIUS,                  -1.0,             NoMin_double,   NoMax_double  );
    ReadPara->Add( "GREP_MINBINSIZE",           &GREP_MINBINSIZE,                 -1.0,             NoMin_double,   NoMax_double  );
-   ReadPara->Add( "GREP_OPT_FIXUP",            &GREP_OPT_FIXUP,                   false,           Useless_bool,   Useless_bool  );
+   ReadPara->Add( "GREP_OPT_FIXUP",            &GREP_OPT_FIXUP,                   true,            Useless_bool,   Useless_bool  );
 #  endif // #ifdef GRAVITY
 
 

--- a/src/Main/Main.cpp
+++ b/src/Main/Main.cpp
@@ -263,6 +263,7 @@ bool   GREP_LOGBIN;
 double GREP_LOGBINRATIO;
 double GREP_MAXRADIUS;
 double GREP_MINBINSIZE;
+bool   GREP_OPT_FIXUP;
 
 // (2-11) source terms
 SrcTerms_t SrcTerms;

--- a/src/Output/Output_DumpData_Total_HDF5.cpp
+++ b/src/Output/Output_DumpData_Total_HDF5.cpp
@@ -2560,6 +2560,7 @@ void FillIn_InputPara( InputPara_t &InputPara, const int NFieldStored, char Fiel
    InputPara.GREP_LogBinRatio        = GREP_LOGBINRATIO;
    InputPara.GREP_MaxRadius          = GREP_MAXRADIUS;
    InputPara.GREP_MinBinSize         = GREP_MINBINSIZE;
+   InputPara.GREP_Opt_FixUp          = GREP_OPT_FIXUP;
 #  endif // #ifdef GRAVITY
 
 // source terms
@@ -3435,6 +3436,7 @@ void GetCompound_InputPara( hid_t &H5_TypeID, const int NFieldStored )
    H5Tinsert( H5_TypeID, "GREP_LogBinRatio",        HOFFSET(InputPara_t,GREP_LogBinRatio       ), H5T_NATIVE_DOUBLE  );
    H5Tinsert( H5_TypeID, "GREP_MaxRadius",          HOFFSET(InputPara_t,GREP_MaxRadius         ), H5T_NATIVE_DOUBLE  );
    H5Tinsert( H5_TypeID, "GREP_MinBinSize",         HOFFSET(InputPara_t,GREP_MinBinSize        ), H5T_NATIVE_DOUBLE  );
+   H5Tinsert( H5_TypeID, "GREP_Opt_FixUp",          HOFFSET(InputPara_t,GREP_Opt_FixUp         ), H5T_NATIVE_INT     );
 #  endif // #ifdef GRAVITY
 
 // source terms

--- a/src/SelfGravity/CPU_Poisson/CPU_ComputeGREP.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_ComputeGREP.cpp
@@ -117,12 +117,12 @@ void CPU_ComputeGREP( const Profile_t *DensAve, const Profile_t *EngyAve, const 
             printf("LogBinRatio        : %13.7e\n",               DensAve->LogBinRatio);
             printf("NBin               : %d\n",                   NBin);
             printf("============================================================\n");
-            printf("%5s %9s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s\n",
+            printf("%5s %9s %22s %22s %22s %22s %22s %22s %22s %22s %22s %22s\n",
                    "Bin", "NCell", "Radius", "Dens", "Engy", "Vr", "Pressure",
                    "Mass_NW", "Mass_TOV", "Mass_TOV_old", "Error_rel", "Gamma_TOV");
 
             for (int i=0; i<NBin; i++)
-               printf("%5d %9ld %10.2e %10.2e %10.2e %10.2e %10.2e %10.2e %10.2e %12.2e %10.2e %10.2e\n",
+               printf("%5d %9ld %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %12.2e %22.15e %22.15e\n",
                       i, DensAve->NCell[i], Radius[i],
                       DensAve->Data[i], EngyAve->Data[i], VrAve->Data[i], PresAve->Data[i],
                       Mass_NW[i], Mass_TOV[i], Mass_TOV_USG[i],
@@ -185,12 +185,12 @@ void CPU_ComputeGREP( const Profile_t *DensAve, const Profile_t *EngyAve, const 
       printf("Num of Iterations  : %d\n",                   GREP_MAXITER - NIter);
       printf("NBin               : %d\n",                   NBin);
       printf("============================================================\n");
-      printf("%5s %9s %10s %10s %10s %10s %10s %10s %10s %10s %10s\n",
+      printf("%5s %9s %22s %22s %22s %22s %22s %22s %22s %22s %23s\n",
              "Bin", "NCell", "Radius", "Dens", "Engy", "Vr", "Pressure",
              "Mass_NW", "Mass_TOV", "Gamma_TOV", "Eff_Pot");
 
       for (int i=0; i<NBin; i++)
-         printf("%5d %9ld %10.2e %10.2e %10.2e %10.2e %10.2e %10.2e %10.2e %10.2e %10.2e\n",
+         printf("%5d %9ld %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %23.15e\n",
                 i, DensAve->NCell[i], Radius[i], DensAve->Data[i], EngyAve->Data[i], VrAve->Data[i], PresAve->Data[i],
                 Mass_NW[i], Mass_TOV[i], Gamma_TOV[i], Phi_eff->Data[i]);
    }

--- a/src/SelfGravity/CPU_Poisson/CPU_ComputeGREP.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_ComputeGREP.cpp
@@ -122,7 +122,7 @@ void CPU_ComputeGREP( const Profile_t *DensAve, const Profile_t *EngyAve, const 
                    "Mass_NW", "Mass_TOV", "Mass_TOV_old", "Error_rel", "Gamma_TOV");
 
             for (int i=0; i<NBin; i++)
-               printf("%5d %9ld %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %12.2e %22.15e %22.15e\n",
+               printf("%5d %9ld %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e\n",
                       i, DensAve->NCell[i], Radius[i],
                       DensAve->Data[i], EngyAve->Data[i], VrAve->Data[i], PresAve->Data[i],
                       Mass_NW[i], Mass_TOV[i], Mass_TOV_USG[i],

--- a/src/SelfGravity/CPU_Poisson/CPU_ExtPot_GREP.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_ExtPot_GREP.cpp
@@ -34,7 +34,12 @@ extern Profile_t *Phi_eff [NLEVEL  ][2];
        void Init_GREP_MemAllocate();
        void End_ExtPot_GREP_MemFree();
 extern void (*Poi_UserWorkBeforePoisson_Ptr)( const double Time, const int lv );
+extern void (*Mis_UserWorkBeforeNextLevel_Ptr)( const int lv, const double TimeNew, const double TimeOld, const double dt );
+extern void (*Mis_UserWorkBeforeNextSubstep_Ptr)( const int lv, const double TimeNew, const double TimeOld, const double dt );
 extern void Poi_UserWorkBeforePoisson_GREP( const double Time, const int lv );
+extern void Mis_UserWorkBeforeNextLevel_GREP( const int lv, const double TimeNew, const double TimeOld, const double dt );
+extern void Mis_UserWorkBeforeNextSubstep_GREP( const int lv, const double TimeNew, const double TimeOld, const double dt );
+
 
 #endif // #ifdef __CUDACC__ ... else ...
 
@@ -371,7 +376,10 @@ void Init_ExtPot_GREP()
 {
 
 // set the function pointer for the built-in GREP
-   Poi_UserWorkBeforePoisson_Ptr = Poi_UserWorkBeforePoisson_GREP;
+   Poi_UserWorkBeforePoisson_Ptr     = Poi_UserWorkBeforePoisson_GREP;
+   Mis_UserWorkBeforeNextLevel_Ptr   = Mis_UserWorkBeforeNextLevel_GREP;
+   Mis_UserWorkBeforeNextSubstep_Ptr = Mis_UserWorkBeforeNextSubstep_GREP;
+
 
    Init_GREP();
    SetExtPotAuxArray_GREP( ExtPot_AuxArray_Flt, ExtPot_AuxArray_Int, Time[0] );

--- a/src/SelfGravity/CPU_Poisson/CPU_ExtPot_GREP.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_ExtPot_GREP.cpp
@@ -40,7 +40,6 @@ extern void Poi_UserWorkBeforePoisson_GREP( const double Time, const int lv );
 extern void Mis_UserWorkBeforeNextLevel_GREP( const int lv, const double TimeNew, const double TimeOld, const double dt );
 extern void Mis_UserWorkBeforeNextSubstep_GREP( const int lv, const double TimeNew, const double TimeOld, const double dt );
 
-
 #endif // #ifdef __CUDACC__ ... else ...
 
 
@@ -379,7 +378,6 @@ void Init_ExtPot_GREP()
    Poi_UserWorkBeforePoisson_Ptr     = Poi_UserWorkBeforePoisson_GREP;
    Mis_UserWorkBeforeNextLevel_Ptr   = Mis_UserWorkBeforeNextLevel_GREP;
    Mis_UserWorkBeforeNextSubstep_Ptr = Mis_UserWorkBeforeNextSubstep_GREP;
-
 
    Init_GREP();
    SetExtPotAuxArray_GREP( ExtPot_AuxArray_Flt, ExtPot_AuxArray_Int, Time[0] );

--- a/src/SelfGravity/Poi_UserWorkBeforePoisson_GREP.cpp
+++ b/src/SelfGravity/Poi_UserWorkBeforePoisson_GREP.cpp
@@ -34,7 +34,7 @@ extern real *h_ExtPotGREP;
 // switch for when the temporal interpolation is applied
 //   true : in Aux_ComputeProfile()
 //   false: when combining the stored profiles
-static bool GREP_OPT_TEMPINT = false;
+static bool GREP_OPT_TIMEINTERP = false;
 
 
 
@@ -198,7 +198,7 @@ void Poi_Prepare_GREP( const double Time, const int lv )
 
 
 // update and combine the spherical-averaged profiles
-   if ( GREP_OPT_TEMPINT )
+   if ( GREP_OPT_TIMEINTERP )
       Update_GREP_Profile( lv, Sg, Time );
 
    else
@@ -249,7 +249,7 @@ static void Update_GREP_Profile( const int lv, const int Sg, const double PrepTi
    Profile_t *Prof_NonLeaf [] = { DensAve[NLEVEL][Sg], VrAve[NLEVEL][Sg], PresAve[NLEVEL][Sg], EngyAve[NLEVEL][Sg] };
 
 
-   if ( GREP_OPT_TEMPINT )
+   if ( GREP_OPT_TIMEINTERP )
    {
 //    contributions from the leaf patches on level <= lv and the non-leaf patches on level = lv
       Aux_ComputeProfile( Prof_NonLeaf, GREP_Prof_Center, GREP_Prof_MaxRadius, GREP_Prof_MinBinSize,

--- a/src/SelfGravity/Poi_UserWorkBeforePoisson_GREP.cpp
+++ b/src/SelfGravity/Poi_UserWorkBeforePoisson_GREP.cpp
@@ -159,8 +159,9 @@ void Mis_UserWorkBeforeNextLevel_GREP( const int lv, const double TimeNew, const
 void Mis_UserWorkBeforeNextSubstep_GREP( const int lv, const double TimeNew, const double TimeOld, const double dt )
 {
 
-   if ( !GREP_OPT_FIXUP        )   return;
-   if ( NPatchTotal[lv+1] == 0 )   return;
+   if (  ( !GREP_OPT_FIXUP                        )  ||
+         ( NPatchTotal[lv+1] == 0                 )  ||
+         ( AdvanceCounter[lv] % REGRID_COUNT != 0 )     )   return;
 
 
    int        Sg           = GREPSg[lv];

--- a/src/SelfGravity/Poi_UserWorkBeforePoisson_GREP.cpp
+++ b/src/SelfGravity/Poi_UserWorkBeforePoisson_GREP.cpp
@@ -207,7 +207,7 @@ static void Update_GREP_Profile( const int lv, const int Sg, const double PrepTi
       if (  ( lv > 0 )  &&  ( lv != GREP_LvUpdate )  )
       {
 //       update Vr, Eint, and Pres at TimeNew
-//       accounts for the Poisson + gravity solver and source terms
+//       accounts for the Poisson + gravity solvers and source terms (Step 4 and 6 in EvolveLevel)
          int        FaLv              = lv - 1;
          int        Sg_FaLv           = GREPSg[FaLv];
          double     Time              = GREPSgTime[FaLv][Sg_FaLv];
@@ -218,7 +218,7 @@ static void Update_GREP_Profile( const int lv, const int Sg, const double PrepTi
                              GREP_LOGBIN, GREP_LOGBINRATIO, false, TVar_FaLv, 3, FaLv, FaLv, PATCH_LEAF, Time );
 
 //       update Dens, Vr, Eint, and Pres at TimeOld
-//       accounts for the flux correction and patch allocation/deallocation
+//       accounts for the flux correction and patch allocation/deallocation (Step 10 and 11 in EvolveLevel)
          if (  GREP_OPT_FIXUP  &&  ( GREPSgTime[FaLv][1 - Sg_FaLv] != -__FLT_MAX__ )  )
          {
             int        Sg_FaLv_Old           = 1 - Sg_FaLv;
@@ -239,7 +239,7 @@ static void Update_GREP_Profile( const int lv, const int Sg, const double PrepTi
 
 //-------------------------------------------------------------------------------------------------------
 // Function    :  Combine_GREP_Profile
-// Description :  Combine the stored spherical-averaged profiles for each level
+// Description :  Combine the stored spherical-averaged profiles on each level
 //                and remove the empty bins in the combined profile
 //
 // Note        :  1. The total averaged profile is stored at QUANT[NLEVEL]
@@ -260,7 +260,7 @@ void Combine_GREP_Profile( Profile_t *Prof[][2], const int lv, const int Sg, con
    Profile_t *Prof_Leaf;
 
 
-// multiply the stored data by weigth to reduce round-off errors
+// multiply the stored data by weight to reduce round-off errors
    for (int b=0; b<Prof_NonLeaf->NBin; b++)
    {
       if ( Prof_NonLeaf->NCell[b] != 0L )   Prof_NonLeaf->Data[b] *= Prof_NonLeaf->Weight[b];

--- a/src/SelfGravity/Poi_UserWorkBeforePoisson_GREP.cpp
+++ b/src/SelfGravity/Poi_UserWorkBeforePoisson_GREP.cpp
@@ -128,7 +128,11 @@ void Poi_UserWorkBeforePoisson_GREP( const double Time, const int lv )
 void Mis_UserWorkBeforeNextLevel_GREP( const int lv, const double TimeNew, const double TimeOld, const double dt )
 {
 
-   if ( NPatchTotal[lv+1] == 0 )   return;
+   if ( lv == TOP_LEVEL )   return;
+
+   if (  ( NPatchTotal[lv+1] == 0 )                      &&
+         ( AdvanceCounter[lv] + 1 ) % REGRID_COUNT != 0     )   return;
+
 
 
    int        Sg           = GREPSg[lv];
@@ -159,9 +163,10 @@ void Mis_UserWorkBeforeNextLevel_GREP( const int lv, const double TimeNew, const
 void Mis_UserWorkBeforeNextSubstep_GREP( const int lv, const double TimeNew, const double TimeOld, const double dt )
 {
 
-   if (  ( !GREP_OPT_FIXUP                        )  ||
-         ( NPatchTotal[lv+1] == 0                 )  ||
-         ( AdvanceCounter[lv] % REGRID_COUNT != 0 )     )   return;
+   if ( lv == TOP_LEVEL )   return;
+
+   if (  ( !GREP_OPT_FIXUP  &&  AdvanceCounter[lv] % REGRID_COUNT != 0 )  ||
+         ( NPatchTotal[lv+1] == 0 )                                          )   return;
 
 
    int        Sg           = GREPSg[lv];


### PR DESCRIPTION
- Optimize the GREP algorithm
- Add the runtime parameter `GREP_OPT_FIXUP` controlling whether the profiles on the father level at `TimeOld` are updated
  - accounts for the flux correction and patch allocation/deallocation
