### PR TITLE
Move functions for gathering AMR tree structure to LB_GatherTree

### DIFF
--- a/include/Patch.h
+++ b/include/Patch.h
@@ -1101,5 +1101,83 @@ struct patch_t
 }; // struct patch_t
 
 
+class NonCopyable
+{
+  protected:
+    NonCopyable() {}
+    ~NonCopyable() {}
+  private: 
+    NonCopyable(const NonCopyable &);
+    NonCopyable& operator=(const NonCopyable &);
+}; // class NonCopyable
+
+struct LB_GlobalPatch
+{
+   int    corner[3];
+   int    sibling[26];
+   int    father;
+   int    son;
+   long   LB_Idx;
+   int    level; 
+#  ifdef PARTICLE
+   int    NPar;
+#  endif 
+}; // struct LB_GlobalPatch
+
+struct LB_PatchCount : private NonCopyable
+{
+   LB_PatchCount();
+   ~LB_PatchCount();
+
+   long NPatchAllLv;
+   int NPatchLocalLv;
+   int NPatchLocal[NLEVEL]; // number of patches per level on MPI_Rank
+   int (*NPatchAllRank)[NLEVEL]; // number of patches in [MPI rank][level]
+   int GID_Offset[NLEVEL]; // offsets that can be used to convert local PID at level lv to GID via GID = PID + GID_Offset[lv]
+   int GID_LvStart[NLEVEL]; // global patch index at which level starts 
+   bool isInitialised;
+}; // struct LB_PatchCount
+
+
+// allocate memory and store pointers to lists with local patch information
+struct LB_LocalPatchExchangeList : private NonCopyable
+{
+   LB_LocalPatchExchangeList();
+   ~LB_LocalPatchExchangeList();
+
+   long *LBIdxList_Local[NLEVEL];         // load balance ids 
+   int  (*CrList_Local   [NLEVEL])[3];    // patch corners
+   int   *FaList_Local   [NLEVEL];        // father GIDs
+   int   *SonList_Local  [NLEVEL];        // son GIDs
+   int  (*SibList_Local  [NLEVEL])[26];   // sibling GIDs
+#  ifdef PARTICLE
+   int   *NParList_Local [NLEVEL]         // particle GIDs
+#  endif
+   bool  isInitialised;
+
+   long *LBIdxList_Sort         [NLEVEL];
+   int  *LBIdxList_Sort_IdxTable[NLEVEL];
+   bool  LBIdxisInitialised; 
+}; // struct LB_LocalPatchExchangeList
+
+
+// allocate memory and store pointers to lists with global patch information
+struct LB_GlobalPatchExchangeList : private NonCopyable
+{
+   LB_GlobalPatchExchangeList(LB_PatchCount& pc, int root);
+   ~LB_GlobalPatchExchangeList();
+
+   long *LBIdxList_AllLv;     // load balance ids
+   int  (*CrList_AllLv)[3];   // patch corners 
+   int  *FaList_AllLv;        // father GIDs
+   int  *SonList_AllLv;       // son GIDs
+   int  (*SibList_AllLv)[26]; // sibling GIDs
+#  ifdef PARTICLE
+   int  *NParList_AllLv;      // particle numbers
+#  endif
+   bool isAllocated;
+   bool isInitialised;
+}; // struct LB_GlobalPatchExchangeList
+
 
 #endif // #ifndef __PATCH_H__

--- a/include/Patch.h
+++ b/include/Patch.h
@@ -1114,9 +1114,9 @@ class NonCopyable
 struct LB_GlobalPatch
 {
    int    corner[3];
-   int    sibling[26];
-   int    father;
-   int    son;
+   long   sibling[26];
+   long   father;
+   long   son;
    long   LB_Idx;
    int    level; 
 #  ifdef PARTICLE

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -410,6 +410,16 @@ void TABLE_GetSibPID_Based( const int lv, const int PID0, int SibPID_Based[] );
 
 // LoadBalance
 long LB_Corner2Index( const int lv, const int Corner[], const Check_t Check );
+
+void LB_GetPID(long GID, int& level, int& PID, int* GID_Offset);
+void LB_AllgatherPatchCount(LB_PatchCount& pc);
+void LB_AllgatherLBIdx(LB_PatchCount& pc, LB_LocalPatchExchangeList& lel, LB_GlobalPatchExchangeList* gel = NULL);
+void LB_FillLocalPatchExchangeList(LB_PatchCount& pc, LB_LocalPatchExchangeList& lel);
+void LB_FillGlobalPatchExchangeList(LB_PatchCount& pc, LB_LocalPatchExchangeList& lel, LB_GlobalPatchExchangeList& gel, int root);
+LB_GlobalPatch* LB_ConstructGlobalTree(LB_PatchCount& pc, LB_GlobalPatchExchangeList& gel, int root);
+LB_GlobalPatch* LB_GatherTree(LB_PatchCount& pc, int root);
+LB_GlobalPatch* LB_AllgatherTree(LB_PatchCount& pc);
+
 #ifdef LOAD_BALANCE
 void LB_AllocateBufferPatch_Father( const int SonLv, const bool SearchAllSon, const int NInput, int* TargetSonPID0,
                                     const bool RecordFaPID, int* NNewFaBuf0, int** NewFaBufPID0 );

--- a/src/LoadBalance/LB_GatherTree.cpp
+++ b/src/LoadBalance/LB_GatherTree.cpp
@@ -1,0 +1,621 @@
+#include "GAMER.h"
+
+/*
+Instructions for adding new patch_t members to GatherTree:
+-> modify "patch.h"
+-  add member to LB_GlobalPatch 
+-  add lists to LB_LocalPatchExchangeList and LB_GlobalPatchExchangeList
+-> modify "LB_GatherTree.cpp"
+-  read new member in LB_FillLocalExchangeList
+-  transfer member in LB_FillGlobalExchangeList 
+-  write member to LB_GlobalPatch in LB_ConstructGlobalTree
+*/
+
+
+LB_PatchCount::LB_PatchCount() : NPatchAllLv(0), NPatchLocalLv(0), isInitialised(false) {
+   NPatchAllRank = new int [MPI_NRank][NLEVEL];
+   for (int lv=0; lv<NLEVEL; lv++)
+   {
+      for (int r=0; r<MPI_Rank; r++) NPatchAllRank[r][lv] = 0; 
+      NPatchLocal[lv] = 0; 
+      GID_Offset[lv] = 0; 
+      GID_LvStart[lv] = 0;
+   }
+}
+
+
+LB_PatchCount::~LB_PatchCount() {
+   delete [] NPatchAllRank;
+}
+
+LB_LocalPatchExchangeList::LB_LocalPatchExchangeList() : isInitialised(false), LBIdxisInitialised(false) {
+   // local lists for storing local tree structure
+   for (int lv=0; lv<NLEVEL; lv++)
+   {
+      LBIdxList_Local        [lv] = new long [ amr->NPatchComma[lv][1] ];
+      CrList_Local           [lv] = new int  [ amr->NPatchComma[lv][1] ][3];
+      FaList_Local           [lv] = new int  [ amr->NPatchComma[lv][1] ];
+      SonList_Local          [lv] = new int  [ amr->NPatchComma[lv][1] ];
+      SibList_Local          [lv] = new int  [ amr->NPatchComma[lv][1] ][26];
+#        ifdef PARTICLE
+      NParList_Local         [lv] = new int  [ amr->NPatchComma[lv][1] ];
+#        endif
+
+      LBIdxList_Sort         [lv] = new long [ NPatchTotal[lv] ];
+      LBIdxList_Sort_IdxTable[lv] = new int  [ NPatchTotal[lv] ];
+   }
+
+}
+
+LB_LocalPatchExchangeList::~LB_LocalPatchExchangeList() { 
+   for (int lv=0; lv<NLEVEL; lv++)
+   {
+      delete [] LBIdxList_Local[lv];
+      delete []    CrList_Local[lv];
+      delete []    FaList_Local[lv];
+      delete []   SonList_Local[lv];
+      delete []   SibList_Local[lv];
+#        ifdef PARTICLE
+      delete []  NParList_Local[lv];
+#        endif
+
+      delete [] LBIdxList_Sort [lv];
+      delete [] LBIdxList_Sort_IdxTable[lv];
+   }
+}
+
+
+// allocate memory and store pointers to lists with global patch information
+LB_GlobalPatchExchangeList::LB_GlobalPatchExchangeList(LB_PatchCount& pc, int root) : isAllocated(false), isInitialised(false) {
+// allocate lists for all ranks or for root rank
+   if ( root < 0 || root == MPI_Rank) {
+      LBIdxList_AllLv = new long [ pc.NPatchAllLv ];
+      CrList_AllLv    = new int  [ pc.NPatchAllLv ][3];
+      FaList_AllLv    = new int  [ pc.NPatchAllLv ];
+      SonList_AllLv   = new int  [ pc.NPatchAllLv ];
+      SibList_AllLv   = new int  [ pc.NPatchAllLv ][26];
+#     ifdef PARTICLE
+      NParList_AllLv  = new int  [ pc.NPatchAllLv ];
+#     endif // # ifdef PARTICLE
+      isAllocated     = true;
+   } else {
+      LBIdxList_AllLv = NULL; 
+      CrList_AllLv    = NULL; 
+      FaList_AllLv    = NULL; 
+      SonList_AllLv   = NULL; 
+      SibList_AllLv   = NULL; 
+#     ifdef PARTICLE
+      NParList_AllLv  = NULL; 
+#     endif // # ifdef PARTICLE
+   }
+}
+
+LB_GlobalPatchExchangeList::~LB_GlobalPatchExchangeList() {
+   if ( isAllocated ) {
+      delete [] LBIdxList_AllLv;
+      delete []    CrList_AllLv;
+      delete []    FaList_AllLv;
+      delete []   SonList_AllLv;
+      delete []   SibList_AllLv;
+#     ifdef PARTICLE
+      delete []  NParList_AllLv;
+#     endif // #ifdef PARTICLE
+   }
+}
+
+
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  LB_GetPID
+// Description :  Convert GID to local PID
+//
+// Note        :  1. Calculate PID and level from PID.
+//
+// Parameter   :  GID        : GID to convert
+//                level      : fill in level of GID.
+//                PID        : fill in PID of GID
+//                GID_Offset : table with GID offsets on rank
+//
+// Return      :  *level, *PID
+//-------------------------------------------------------------------------------------------------------
+void LB_GetPID(long GID, int& level, int& PID, int* GID_Offset) {
+#   ifdef GAMER_DEBUG
+    long NPatchAllLv = 0;
+    for (int lv=0; lv<NLEVEL; lv++)  NPatchAllLv += NPatchTotal[lv];
+    if ( GID < 0  ||  GID >= NPatchAllLv )  Aux_Error( ERROR_INFO, "incorrect gid %ld (max = %ld) !!\n", GID, NPatchAllLv-1 );
+#   endif
+
+   level = 0;
+
+   for(int lv = 1; lv < NLEVEL; lv++) {
+      if ( GID < GID_Offset[lv] )      
+        break;
+      level = lv;
+   }
+
+   PID = GID - GID_Offset[level];
+}
+
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  LB_AllgatherPatchCount
+// Description :  Gather the number of patches at different MPI ranks and set the corresponding GID offset
+//
+// Note        :  - store data in LB_PatchCount& pc
+//
+// Parameter   :  pc   : reference to LB_PatchCount object
+//-------------------------------------------------------------------------------------------------------
+void LB_AllgatherPatchCount(LB_PatchCount& pc) {
+
+   pc.NPatchLocalLv = 0; 
+   pc.NPatchAllLv   = 0;
+
+   for (int lv=0; lv<NLEVEL; lv++)  {
+      pc.NPatchLocal[lv] = amr->NPatchComma[lv][1];
+      pc.NPatchLocalLv += pc.NPatchLocal[lv];
+   }
+
+   MPI_Allgather( pc.NPatchLocal, NLEVEL, MPI_INT, pc.NPatchAllRank[0], NLEVEL, MPI_INT, MPI_COMM_WORLD );
+
+   for (int lv=0; lv<NLEVEL; lv++)
+   {
+      pc.GID_Offset[lv] = 0;
+
+      for (int r=0; r<MPI_Rank; r++)      pc.GID_Offset[lv] += pc.NPatchAllRank[r][lv];
+
+      for (int FaLv=0; FaLv<lv; FaLv++)   pc.GID_Offset[lv] += NPatchTotal[FaLv];
+
+      pc.NPatchAllLv += NPatchTotal[lv];
+
+      pc.GID_LvStart[lv] = ( lv == 0 ) ? 0 : pc.GID_LvStart[lv-1] + NPatchTotal[lv-1];
+   }
+
+   pc.isInitialised = true; 
+}
+
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  LB_AllgatherLBIdx
+// Description :  Collect and sort LBIdx from all ranks
+//
+// Note        :  - pc requires initialisation by calling LB_AllgatherPatchCount
+//
+// Parameter   :  pc   : reference to LB_PatchCount object
+//             :  lel  : reference to LB_LocalPatchExchangeList
+//             :  gel  : reference to LB_GlobalPatchExchangeList
+//             :  root : root MPI rank, -1 for all ranks
+//-------------------------------------------------------------------------------------------------------
+void LB_AllgatherLBIdx(LB_PatchCount& pc, LB_LocalPatchExchangeList& lel, LB_GlobalPatchExchangeList* gel)  {
+
+#  ifdef GAMER_DEBUG
+   if ( !pc.isInitialised ) 
+      Aux_Error( ERROR_INFO, "call LB_AllgatherLBIdx without initialising LB_PatchCount object !!\n");
+#  endif 
+
+   int RecvCount_LBIdx[MPI_NRank], RecvDisp_LBIdx[MPI_NRank];
+
+   for (int lv=0; lv<NLEVEL; lv++)
+   {
+      for (int r=0; r<MPI_NRank; r++)
+      {
+         RecvCount_LBIdx[r] = pc.NPatchAllRank[r][lv];
+         RecvDisp_LBIdx [r] = ( r == 0 ) ? 0 : RecvDisp_LBIdx[r-1] + RecvCount_LBIdx[r-1];
+      }
+
+      for (int PID=0; PID<amr->NPatchComma[lv][1]; PID++)
+         lel.LBIdxList_Local[lv][PID] = amr->patch[0][lv][PID]->LB_Idx;
+
+//    all ranks need to get LBIdxList_Sort since we will use it to calculate GID
+      MPI_Allgatherv( lel.LBIdxList_Local[lv], amr->NPatchComma[lv][1], MPI_LONG,
+                      lel.LBIdxList_Sort[lv], RecvCount_LBIdx, RecvDisp_LBIdx, MPI_LONG,
+                      MPI_COMM_WORLD );
+   } // for (int lv=0; lv<NLEVEL; lv++)
+
+// store in the AllLv array BEFORE sorting
+   if ( gel != NULL ) {
+      if ( gel->isAllocated ) {
+         long MyGID = 0;
+
+         for (int lv=0; lv<NLEVEL; lv++)
+         for (int PID=0; PID<NPatchTotal[lv]; PID++)
+            gel->LBIdxList_AllLv[ MyGID++ ] = lel.LBIdxList_Sort[lv][PID];
+      }
+   }
+
+// sort list and get the corresponding index table (for calculating GID later)
+   for (int lv=0; lv<NLEVEL; lv++)
+      Mis_Heapsort( NPatchTotal[lv], lel.LBIdxList_Sort[lv], lel.LBIdxList_Sort_IdxTable[lv] );
+
+   lel.LBIdxisInitialised = true; 
+}
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  LB_FillLocalPatchExchangeList
+// Description :  Fill local exchange list by reading amr->patch structure on local MPI rank
+//
+// Note        :  - pc requires initialisation by calling LB_AllgatherPatchCount
+//                - lel requires initialisation by calling LB_AllgatherLBIdx
+//
+// Parameter   :  pc   : reference to LB_PatchCount object
+//             :  lel  : reference to LB_LocalPatchExchangeList
+//-------------------------------------------------------------------------------------------------------
+void LB_FillLocalPatchExchangeList(LB_PatchCount& pc, LB_LocalPatchExchangeList& lel) {
+
+#  ifdef GAMER_DEBUG
+   if ( !pc.isInitialised ) 
+      Aux_Error( ERROR_INFO, "call LB_FillLocalExchangeList without initialising LB_PatchCount object !!\n");
+   if ( !lel.LBIdxisInitialised ) 
+      Aux_Error( ERROR_INFO, "call LB_FillLocalExchangeList without initialising load balancing id lists object !!\n");
+#  endif 
+
+// temporary variables
+   int   MyGID, FaPID, FaGID, FaLv, SonPID, SonGID, SonLv, SibPID, SibGID, MatchIdx;
+   long  FaLBIdx, SonLBIdx, SibLBIdx;
+   int  *SonCr=NULL, *SibCr=NULL;
+
+// 4. store the local tree
+   for (int lv=0; lv<NLEVEL; lv++)
+   {
+      for (int PID=0; PID<amr->NPatchComma[lv][1]; PID++)
+      {
+//       4-1. LBIdx (set already)
+//       lel.LBIdxList_Local[lv][PID] = amr->patch[0][lv][PID]->LB_Idx;
+
+
+//       4-2. corner
+         for (int d=0; d<3; d++)
+         lel.CrList_Local[lv][PID][d] = amr->patch[0][lv][PID]->corner[d];
+
+
+//       4-3. father GID
+         FaPID = amr->patch[0][lv][PID]->father;
+         FaLv  = lv - 1;
+
+//       no father (only possible for the root patches)
+         if ( FaPID < 0 )
+         {
+#           ifdef GAMER_DEBUG
+            if ( lv != 0 )       Aux_Error( ERROR_INFO, "Lv %d, PID %d, FaPID %d < 0 !!\n", lv, PID, FaPID );
+            if ( FaPID != -1 )   Aux_Error( ERROR_INFO, "Lv %d, PID %d, FaPID %d < 0 but != -1 !!\n", lv, PID, FaPID );
+#           endif
+
+            FaGID = FaPID;
+         }
+
+//       father patch is a real patch
+         else if ( FaPID < amr->NPatchComma[FaLv][1] )
+            FaGID = FaPID + pc.GID_Offset[FaLv];
+
+//       father patch is a buffer patch (only possible in LOAD_BALANCE)
+         else // (FaPID >= amr->NPatchComma[FaLv][1] )
+         {
+#           ifdef GAMER_DEBUG
+#           ifndef LOAD_BALANCE
+            Aux_Error( ERROR_INFO, "Lv %d, PID %d, FaPID %d >= NRealFaPatch %d (only possible in LOAD_BALANCE) !!\n",
+                       lv, PID, FaPID, amr->NPatchComma[FaLv][1] );
+#           endif
+
+            if ( FaPID >= amr->num[FaLv] )
+            Aux_Error( ERROR_INFO, "Lv %d, PID %d, FaPID %d >= total number of patches %d !!\n",
+                       lv, PID, FaPID, amr->num[FaLv] );
+#           endif // GAMER_DEBUG
+
+            FaLBIdx = amr->patch[0][FaLv][FaPID]->LB_Idx;
+
+            Mis_Matching_int( NPatchTotal[FaLv], lel.LBIdxList_Sort[FaLv], 1, &FaLBIdx, &MatchIdx );
+
+#           ifdef GAMER_DEBUG
+            if ( MatchIdx < 0 )
+            Aux_Error( ERROR_INFO, "Lv %d, PID %d, FaPID %d, FaLBIdx %ld, couldn't find a matching patch !!\n",
+                       lv, PID, FaPID, FaLBIdx );
+#           endif
+
+            FaGID = lel.LBIdxList_Sort_IdxTable[FaLv][MatchIdx] + pc.GID_LvStart[FaLv];
+         } // if ( FaPID >= amr->NPatchComma[FaLv][1] )
+
+         lel.FaList_Local[lv][PID] = FaGID;
+
+
+//       4-4. son GID
+         SonPID = amr->patch[0][lv][PID]->son;
+         SonLv  = lv + 1;
+
+//       no son (must check this first since SonLv may be out of range --> == NLEVEL)
+         if      ( SonPID == -1 )
+            SonGID = SonPID;
+
+//       son patch is a real patch at home
+         else if ( SonPID >= 0  &&  SonPID < amr->NPatchComma[SonLv][1] )
+            SonGID = SonPID + pc.GID_Offset[SonLv];
+
+//       son patch lives abroad (only possible in LOAD_BALANCE)
+         else if ( SonPID < -1 )
+         {
+#           ifdef GAMER_DEBUG
+#           ifdef LOAD_BALANCE
+            const int SonRank = SON_OFFSET_LB - SonPID;
+            if ( SonRank < 0  ||  SonRank == MPI_Rank  ||  SonRank >= MPI_NRank )
+            Aux_Error( ERROR_INFO, "Lv %d, PID %d, SonPID %d, incorrect SonRank %d (MyRank %d, NRank %d) !!\n",
+                       lv, PID, SonPID, SonRank, MPI_Rank, MPI_NRank );
+#           else
+            Aux_Error( ERROR_INFO, "Lv %d, PID %d, SonPID %d < -1 (only possible in LOAD_BALANCE) !!\n",
+                       lv, PID, SonPID );
+#           endif // LOAD_BALANCE
+#           endif // GAMER_DEBUG
+
+//          get the SonGID by "father corner = son corner -> son LB_Idx -> son GID"
+//          --> for Hilbert curve we have "SonLBIdx-SonLBIdx%8 = 8*MyLBIdx"
+            SonCr    = amr->patch[0][lv][PID]->corner;
+            SonLBIdx = LB_Corner2Index( SonLv, SonCr, CHECK_ON );
+
+#           if ( defined GAMER_DEBUG  &&  LOAD_BALANCE == HILBERT )
+            if ( SonLBIdx - SonLBIdx%8 != 8*amr->patch[0][lv][PID]->LB_Idx )
+            Aux_Error( ERROR_INFO, "Lv %d, PID %d, SonPID %d, SonCr (%d,%d,%d), incorret SonLBIdx %ld, (MyLBIdx %ld) !!\n",
+                       lv, PID, SonPID, SonCr[0], SonCr[1], SonCr[2], SonLBIdx, amr->patch[0][lv][PID]->LB_Idx );
+#           endif
+
+            Mis_Matching_int( NPatchTotal[SonLv], lel.LBIdxList_Sort[SonLv], 1, &SonLBIdx, &MatchIdx );
+
+#           ifdef GAMER_DEBUG
+            if ( MatchIdx < 0 )
+            Aux_Error( ERROR_INFO, "Lv %d, PID %d, SonPID %d, SonLBIdx %ld, couldn't find a matching patch !!\n",
+                       lv, PID, SonPID, SonLBIdx );
+#           endif
+
+            SonGID = lel.LBIdxList_Sort_IdxTable[SonLv][MatchIdx] + pc.GID_LvStart[SonLv];
+         } // else if ( SonPID < -1 )
+
+//       son patch is a buffer patch (SonPID >= amr->NPatchComma[SonLv][1]) --> impossible
+         else // ( SonPID >= amr->NPatchComma[SonLv][1] )
+            Aux_Error( ERROR_INFO, "Lv %d, PID %d, SonPID %d is a buffer patch (NRealSonPatch %d) !!\n",
+                       lv, PID, SonPID, amr->NPatchComma[SonLv][1] );
+
+         lel.SonList_Local[lv][PID] = SonGID;
+
+
+//       4-5. sibling GID
+         for (int s=0; s<26; s++)
+         {
+            SibPID = amr->patch[0][lv][PID]->sibling[s];
+
+//          no sibling (SibPID can be either -1 or SIB_OFFSET_NONPERIODIC-BoundaryDirection)
+            if      ( SibPID < 0 )
+               SibGID = SibPID;
+
+//          sibling patch is a real patch
+            else if ( SibPID < amr->NPatchComma[lv][1] )
+               SibGID = SibPID + pc.GID_Offset[lv];
+
+//          sibling patch is a buffer patch (which may lie outside the simulation domain)
+            else
+            {
+#              ifdef GAMER_DEBUG
+               if ( SibPID >= amr->num[lv] )
+               Aux_Error( ERROR_INFO, "Lv %d, PID %d, SibPID %d >= total number of patches %d !!\n",
+                          lv, PID, SibPID, amr->num[lv] );
+#              endif
+
+//             get the SibGID by "sibling corner -> sibling LB_Idx -> sibling GID"
+               SibCr    = amr->patch[0][lv][SibPID]->corner;
+               SibLBIdx = LB_Corner2Index( lv, SibCr, CHECK_OFF );   // periodicity has been assumed here
+
+               Mis_Matching_int( NPatchTotal[lv], lel.LBIdxList_Sort[lv], 1, &SibLBIdx, &MatchIdx );
+
+#              ifdef GAMER_DEBUG
+               if ( MatchIdx < 0 )
+               Aux_Error( ERROR_INFO, "Lv %d, PID %d, SibPID %d, SibLBIdx %ld, couldn't find a matching patch !!\n",
+                          lv, PID, SibPID, SibLBIdx );
+#              endif
+
+               SibGID = lel.LBIdxList_Sort_IdxTable[lv][MatchIdx] + pc.GID_LvStart[lv];
+            } // if ( SibPID >= amr->NPatchComma[lv][1] )
+
+            lel.SibList_Local[lv][PID][s] = SibGID;
+
+         } // for (int s=0; s<26; s++)
+
+
+#        ifdef PARTICLE
+//       4-6. NPar
+         lel.NParList_Local[lv][PID] = amr->patch[0][lv][PID]->NPar;
+#        endif
+
+      } // for (int PID=0; PID<amr->NPatchComma[lv][1]; PID++)
+   } // for (int lv=0; lv<NLEVEL; lv++)
+
+   lel.isInitialised = true; 
+}
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  LB_FillGlobalPatchExchangeList
+// Description :  Fill global patch exchange lists by exchanging local patch list data between ranks
+//
+// Note        :  - pc and lel need to be initialised by calling LB_AllgatherPatchCount and LB_FillLocalPatchExchangeList beforehand
+//                - global patch data is written to LB_GlobalPatchExchangeList& gel if root = gel.root or root = -1
+//                - pass root = -1 to exchange local patch list data from all ranks to all ranks
+//
+// Parameter   :  pc   : reference to LB_PatchCount object
+//             :  lel  : reference to LB_LocalPatchExchangeList
+//             :  gel  : reference to LB_GlobalPatchExchangeList
+//             :  root : root MPI rank, -1 for all ranks
+//-------------------------------------------------------------------------------------------------------
+void LB_FillGlobalPatchExchangeList(LB_PatchCount& pc, LB_LocalPatchExchangeList& lel, LB_GlobalPatchExchangeList& gel, int root) {
+#  ifdef GAMER_DEBUG
+   if ( !pc.isInitialised ) 
+      Aux_Error( ERROR_INFO, "call LB_FillGlobalPatchExchangeList without initialising LB_PatchCount object !!\n");
+   if ( !lel.isInitialised ) 
+      Aux_Error( ERROR_INFO, "call LB_FillGlobalPatchExchangeList without initialising LB_LocalPatchExchangeList object !!\n");
+#  endif 
+
+// sending and receiving lists for MPI communication 
+   int   RecvCount_Cr[MPI_NRank],    RecvDisp_Cr[MPI_NRank];
+   int   RecvCount_Fa[MPI_NRank],    RecvDisp_Fa[MPI_NRank];
+   int   RecvCount_Son[MPI_NRank],   RecvDisp_Son[MPI_NRank];
+   int   RecvCount_Sib[MPI_NRank],   RecvDisp_Sib[MPI_NRank];
+#  ifdef PARTICLE
+   int   RecvCount_NPar[MPI_NRank],  RecvDisp_NPar[MPI_NRank];
+#  endif // #  ifdef PARTICLE
+
+
+// 5. gather data from all ranks
+   for (int lv=0; lv<NLEVEL; lv++)
+   {
+      for (int r=0; r<MPI_NRank; r++)
+      {
+         RecvCount_Fa  [r] = pc.NPatchAllRank[r][lv];
+         RecvCount_Son [r] = RecvCount_Fa[r];
+         RecvCount_Sib [r] = RecvCount_Fa[r]*26;
+         RecvCount_Cr  [r] = RecvCount_Fa[r]*3;
+#        ifdef PARTICLE
+         RecvCount_NPar[r] = RecvCount_Fa[r];
+#        endif
+
+         RecvDisp_Fa   [r] = ( r == 0 ) ? 0 : RecvDisp_Fa[r-1] + RecvCount_Fa[r-1];
+         RecvDisp_Son  [r] = RecvDisp_Fa[r];
+         RecvDisp_Sib  [r] = RecvDisp_Fa[r]*26;
+         RecvDisp_Cr   [r] = RecvDisp_Fa[r]*3;
+#        ifdef PARTICLE
+         RecvDisp_NPar [r] = RecvDisp_Fa[r];
+#        endif
+
+      }
+
+//    note that we collect data at one level at a time
+      if (root < 0) {
+         MPI_Allgatherv( lel.FaList_Local[lv],     amr->NPatchComma[lv][1],    MPI_INT,
+                      gel.FaList_AllLv+pc.GID_LvStart[lv],       RecvCount_Fa,   RecvDisp_Fa,   MPI_INT, MPI_COMM_WORLD );
+
+         MPI_Allgatherv( lel.SonList_Local[lv],    amr->NPatchComma[lv][1],    MPI_INT,
+                      gel.SonList_AllLv+pc.GID_LvStart[lv],      RecvCount_Son,  RecvDisp_Son,  MPI_INT, MPI_COMM_WORLD );
+
+         MPI_Allgatherv( lel.SibList_Local[lv][0], amr->NPatchComma[lv][1]*26, MPI_INT,
+                      (gel.SibList_AllLv+pc.GID_LvStart[lv])[0], RecvCount_Sib,  RecvDisp_Sib,  MPI_INT, MPI_COMM_WORLD );
+
+         MPI_Allgatherv( lel.CrList_Local[lv][0],  amr->NPatchComma[lv][1]*3,  MPI_INT,
+                      (gel.CrList_AllLv+pc.GID_LvStart[lv])[0],  RecvCount_Cr,   RecvDisp_Cr,   MPI_INT, MPI_COMM_WORLD );
+
+#        ifdef PARTICLE
+         MPI_Allgatherv( lel.NParList_Local[lv],    amr->NPatchComma[lv][1],    MPI_INT,
+                      gel.NParList_AllLv+pc.GID_LvStart[lv],     RecvCount_NPar, RecvDisp_NPar, MPI_INT, MPI_COMM_WORLD );
+#        endif
+      } else {
+         MPI_Gatherv( lel.FaList_Local[lv],     amr->NPatchComma[lv][1],    MPI_INT,
+                      gel.FaList_AllLv+pc.GID_LvStart[lv],       RecvCount_Fa,   RecvDisp_Fa,   MPI_INT, root, MPI_COMM_WORLD );
+
+         MPI_Gatherv( lel.SonList_Local[lv],    amr->NPatchComma[lv][1],    MPI_INT,
+                      gel.SonList_AllLv+pc.GID_LvStart[lv],      RecvCount_Son,  RecvDisp_Son,  MPI_INT, root, MPI_COMM_WORLD );
+
+         MPI_Gatherv( lel.SibList_Local[lv][0], amr->NPatchComma[lv][1]*26, MPI_INT,
+                      (gel.SibList_AllLv+pc.GID_LvStart[lv])[0], RecvCount_Sib,  RecvDisp_Sib,  MPI_INT, root, MPI_COMM_WORLD );
+
+         MPI_Gatherv( lel.CrList_Local[lv][0],  amr->NPatchComma[lv][1]*3,  MPI_INT,
+                      (gel.CrList_AllLv+pc.GID_LvStart[lv])[0],  RecvCount_Cr,   RecvDisp_Cr,   MPI_INT, root, MPI_COMM_WORLD );
+
+#        ifdef PARTICLE
+         MPI_Gatherv( lel.NParList_Local[lv],    amr->NPatchComma[lv][1],    MPI_INT,
+                      gel.NParList_AllLv+pc.GID_LvStart[lv],     RecvCount_NPar, RecvDisp_NPar, MPI_INT, root, MPI_COMM_WORLD );
+#        endif
+      }
+
+   } // for (int lv=0; lv<NLEVEL; lv++)
+
+   gel.isInitialised = true; 
+}
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  LB_ConstructGlobalTree
+// Description :  Gather global tree structure as vector indexed by GIDs to root rank
+//
+// Note        :  - Store global tree AMR structure gathered from all ranks in vector 
+//                - Example usage: Print level of MPI rank 0's patch's son
+//                      LB_PatchCount pc;
+//                      std::vector<LB_GlobalPatch> t = LB_GatherTree(pc, 0);
+//                      if (t[GID].son != -1) printf(t[t[GID].son].level);
+//
+// Parameter   :  pc   : reference to LB_PatchCount object
+//             :  gel  : reference to LB_GlobalPatchExchangeList that needs to be initialised by calling LB_FillGlobalPatchExchangeList
+//             :  root : root MPI rank that receives global list, -1 for all ranks
+//-------------------------------------------------------------------------------------------------------
+LB_GlobalPatch* LB_ConstructGlobalTree(LB_PatchCount& pc, LB_GlobalPatchExchangeList& gel, int root) {
+   LB_GlobalPatch* global_tree;
+   if ( root >= 0 && root != MPI_Rank )
+      return global_tree; 
+
+#  ifdef GAMER_DEBUG
+   if ( !pc.isInitialised ) 
+      Aux_Error( ERROR_INFO, "call LB_ConstructGlobalTree without initialising LB_PatchCount object !!\n");
+   if ( !gel.isInitialised ) 
+      Aux_Error( ERROR_INFO, "call LB_ConstructGlobalTree without initialising LB_GlobalPatchExchangeListobject !!\n");
+#  endif 
+
+   global_tree = new LB_GlobalPatch[pc.NPatchAllLv];
+
+   long MyGID = 0;
+   for (int lv=0; lv<NLEVEL; lv++)
+   {
+      for (int i = 0; i < NPatchTotal[lv]; ++i) {
+         global_tree[MyGID].level      = lv; 
+         global_tree[MyGID].father     = gel.FaList_AllLv   [MyGID];
+         global_tree[MyGID].son        = gel.SonList_AllLv  [MyGID];
+         for (int s=0; s<26; s++) 
+         global_tree[MyGID].sibling[s] = gel.SibList_AllLv  [MyGID][s];
+         for (int c=0; c<3 ; c++) 
+         global_tree[MyGID].corner[c]  = gel.CrList_AllLv   [MyGID][c];
+#        ifdef PARTICLE
+         global_tree[MyGID].NPar       = gel.NParList_AllLv [MyGID];
+#        endif //# ifdef PARTICLE
+         global_tree[MyGID].LB_Idx     = gel.LBIdxList_AllLv[MyGID];
+         MyGID += 1; 
+      }
+   }
+
+   return global_tree;
+}
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  LB_GatherTree
+// Description :  Gather global tree structure as vector indexed by GIDs to root rank
+//
+// Note        :  - Store global tree AMR structure gathered from all ranks in vector 
+//                - Example usage: Print level of MPI rank 0's patch's son
+//                      LB_PatchCount pc;
+//                      std::vector<LB_GlobalPatch> t = LB_GatherTree(pc, 0);
+//                      if (t[GID].son != -1) printf(t[t[GID].son].level);
+//
+// Parameter   :  pc  : reference to LB_PatchCount object that is filled with the GID offsets for 
+//                      the local rank as well as total number of patches
+//-------------------------------------------------------------------------------------------------------
+
+LB_GlobalPatch* LB_GatherTree(LB_PatchCount& pc, int root) {
+// get patch counts per level and per rank from all ranks
+   LB_AllgatherPatchCount(pc); 
+
+// set up local and global exchange lists
+   LB_LocalPatchExchangeList  lel;
+   LB_GlobalPatchExchangeList gel(pc, root);
+
+// exchange load balance id's between all ranks
+   LB_AllgatherLBIdx(pc, lel, &gel);
+
+// fill local patch lists with information from patches
+   LB_FillLocalPatchExchangeList(pc, lel);
+
+// exchange local patch information with other ranks
+   LB_FillGlobalPatchExchangeList(pc, lel, gel, root);
+
+// construct and return vector with global tree information
+   return LB_ConstructGlobalTree(pc, gel, root);
+}
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  LB_AllgatherTree
+// Description :  Gather global tree structure as vector indexed by GIDs to all ranks
+//
+// Note        :  - see LB_GatherTrees
+//
+// Parameter   :  pc  : reference to LB_PatchCount object that is filled with the GID offsets for the local rank as well as total number of patches
+//-------------------------------------------------------------------------------------------------------
+LB_GlobalPatch* LB_AllgatherTree(LB_PatchCount& pc) {
+// call LB_GatherTree with root = -1 to synchronise data between all ranks
+   return LB_GatherTree(pc, -1);
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -634,7 +634,7 @@ endif # !SERIAL
 
 # load-balance source files (included only if "LOAD_BALANCE" is turned on)
 # ------------------------------------------------------------------------------------
-CPU_FILE    += LB_HilbertCurve.cpp  LB_Utility.cpp
+CPU_FILE    += LB_HilbertCurve.cpp  LB_Utility.cpp LB_GatherTree.cpp
 
 ifeq "$(findstring -DLOAD_BALANCE, $(SIMU_OPTION))" "-DLOAD_BALANCE"
 CPU_FILE    += LB_Init_LoadBalance.cpp  LB_AllocateBufferPatch_Sibling.cpp  LB_RecordOvelapMPIPatchID.cpp \

--- a/src/Output/Output_DumpData_Total_HDF5.cpp
+++ b/src/Output/Output_DumpData_Total_HDF5.cpp
@@ -336,27 +336,8 @@ void Output_DumpData_Total_HDF5( const char *FileName )
 
 
 // 1. gather the number of patches at different MPI ranks and set the corresponding GID offset
-   int (*NPatchAllRank)[NLEVEL] = new int [MPI_NRank][NLEVEL];
-   int NPatchLocal[NLEVEL], NPatchAllLv=0, GID_Offset[NLEVEL], GID_LvStart[NLEVEL];
-
-   for (int lv=0; lv<NLEVEL; lv++)  NPatchLocal[lv] = amr->NPatchComma[lv][1];
-
-   MPI_Allgather( NPatchLocal, NLEVEL, MPI_INT, NPatchAllRank[0], NLEVEL, MPI_INT, MPI_COMM_WORLD );
-
-   for (int lv=0; lv<NLEVEL; lv++)
-   {
-      GID_Offset[lv] = 0;
-
-      for (int r=0; r<MPI_Rank; r++)      GID_Offset[lv] += NPatchAllRank[r][lv];
-
-      for (int FaLv=0; FaLv<lv; FaLv++)   GID_Offset[lv] += NPatchTotal[FaLv];
-
-      NPatchAllLv += NPatchTotal[lv];
-
-      GID_LvStart[lv] = ( lv == 0 ) ? 0 : GID_LvStart[lv-1] + NPatchTotal[lv-1];
-   }
-
-
+   LB_PatchCount pc;
+   LB_AllgatherPatchCount(pc); 
 
 // 2. prepare all HDF5 variables
    hsize_t H5_SetDims_LBIdx, H5_SetDims_Cr[2], H5_SetDims_Fa, H5_SetDims_Son, H5_SetDims_Sib[2], H5_SetDims_Field[4];
@@ -457,303 +438,20 @@ void Output_DumpData_Total_HDF5( const char *FileName )
 
 
 // 4. output the AMR tree structure (father, son, sibling, LBIdx, corner, and the number of particles --> sorted by GID)
-   long *LBIdxList_Local[NLEVEL], *LBIdxList_AllLv;
-   int  (*CrList_Local[NLEVEL])[3], (*CrList_AllLv)[3];
-   int  *FaList_Local[NLEVEL], *FaList_AllLv;
-   int  *SonList_Local[NLEVEL], *SonList_AllLv;
-   int  (*SibList_Local[NLEVEL])[26], (*SibList_AllLv)[26];
-#  ifdef PARTICLE
-   int  *NParList_Local[NLEVEL], *NParList_AllLv;
-#  endif
-
-   long *LBIdxList_Sort[NLEVEL];
-   int  *LBIdxList_Sort_IdxTable[NLEVEL];
-
-   int   MyGID, FaPID, FaGID, FaLv, SonPID, SonGID, SonLv, SibPID, SibGID, MatchIdx;
-   long  FaLBIdx, SonLBIdx, SibLBIdx;
-   int  *SonCr=NULL, *SibCr=NULL;
-
-   int   RecvCount_LBIdx[MPI_NRank], RecvDisp_LBIdx[MPI_NRank], RecvCount_Cr[MPI_NRank], RecvDisp_Cr[MPI_NRank];
-   int   RecvCount_Fa[MPI_NRank], RecvDisp_Fa[MPI_NRank], RecvCount_Son[MPI_NRank], RecvDisp_Son[MPI_NRank];
-   int   RecvCount_Sib[MPI_NRank], RecvDisp_Sib[MPI_NRank];
-#  ifdef PARTICLE
-   int   RecvCount_NPar[MPI_NRank], RecvDisp_NPar[MPI_NRank];
-#  endif
+   int root = 0; 
 
 // 4-1. allocate lists
-   if ( MPI_Rank == 0 )
-   {
-      LBIdxList_AllLv = new long [ NPatchAllLv ];
-      CrList_AllLv    = new int  [ NPatchAllLv ][3];
-      FaList_AllLv    = new int  [ NPatchAllLv ];
-      SonList_AllLv   = new int  [ NPatchAllLv ];
-      SibList_AllLv   = new int  [ NPatchAllLv ][26];
-#     ifdef PARTICLE
-      NParList_AllLv  = new int  [ NPatchAllLv ];
-#     endif
-   }
-
-   for (int lv=0; lv<NLEVEL; lv++)
-   {
-      LBIdxList_Local        [lv] = new long [ amr->NPatchComma[lv][1] ];
-      CrList_Local           [lv] = new int  [ amr->NPatchComma[lv][1] ][3];
-      FaList_Local           [lv] = new int  [ amr->NPatchComma[lv][1] ];
-      SonList_Local          [lv] = new int  [ amr->NPatchComma[lv][1] ];
-      SibList_Local          [lv] = new int  [ amr->NPatchComma[lv][1] ][26];
-#     ifdef PARTICLE
-      NParList_Local         [lv] = new int  [ amr->NPatchComma[lv][1] ];
-#     endif
-
-      LBIdxList_Sort         [lv] = new long [ NPatchTotal[lv] ];
-      LBIdxList_Sort_IdxTable[lv] = new int  [ NPatchTotal[lv] ];
-   }
-
+   LB_LocalPatchExchangeList  lel;
+   LB_GlobalPatchExchangeList gel(pc, root);
 
 // 4-2. collect and sort LBIdx from all ranks
-   for (int lv=0; lv<NLEVEL; lv++)
-   {
-      for (int r=0; r<MPI_NRank; r++)
-      {
-         RecvCount_LBIdx[r] = NPatchAllRank[r][lv];
-         RecvDisp_LBIdx [r] = ( r == 0 ) ? 0 : RecvDisp_LBIdx[r-1] + RecvCount_LBIdx[r-1];
-      }
-
-      for (int PID=0; PID<amr->NPatchComma[lv][1]; PID++)
-         LBIdxList_Local[lv][PID] = amr->patch[0][lv][PID]->LB_Idx;
-
-//    all ranks need to get LBIdxList_Sort since we will use it to calculate GID
-      MPI_Allgatherv( LBIdxList_Local[lv], amr->NPatchComma[lv][1], MPI_LONG,
-                      LBIdxList_Sort[lv], RecvCount_LBIdx, RecvDisp_LBIdx, MPI_LONG,
-                      MPI_COMM_WORLD );
-   } // for (int lv=0; lv<NLEVEL; lv++)
-
-// store in the AllLv array BEFORE sorting
-   if ( MPI_Rank == 0 )
-   {
-      MyGID = 0;
-
-      for (int lv=0; lv<NLEVEL; lv++)
-      for (int PID=0; PID<NPatchTotal[lv]; PID++)
-         LBIdxList_AllLv[ MyGID++ ] = LBIdxList_Sort[lv][PID];
-   }
-
-// sort list and get the corresponding index table (for calculating GID later)
-   for (int lv=0; lv<NLEVEL; lv++)
-      Mis_Heapsort( NPatchTotal[lv], LBIdxList_Sort[lv], LBIdxList_Sort_IdxTable[lv] );
-
+   LB_AllgatherLBIdx(pc, lel, &gel);
 
 // 4-3. store the local tree
-   for (int lv=0; lv<NLEVEL; lv++)
-   {
-      for (int PID=0; PID<amr->NPatchComma[lv][1]; PID++)
-      {
-//       4-3-1. LBIdx (set already)
-//       LBIdxList_Local[lv][PID] = amr->patch[0][lv][PID]->LB_Idx;
-
-
-//       4-3-2. corner
-         for (int d=0; d<3; d++)
-         CrList_Local[lv][PID][d] = amr->patch[0][lv][PID]->corner[d];
-
-
-//       4-3-3. father GID
-         FaPID = amr->patch[0][lv][PID]->father;
-         FaLv  = lv - 1;
-
-//       no father (only possible for the root patches)
-         if ( FaPID < 0 )
-         {
-#           ifdef DEBUG_HDF5
-            if ( lv != 0 )       Aux_Error( ERROR_INFO, "Lv %d, PID %d, FaPID %d < 0 !!\n", lv, PID, FaPID );
-            if ( FaPID != -1 )   Aux_Error( ERROR_INFO, "Lv %d, PID %d, FaPID %d < 0 but != -1 !!\n", lv, PID, FaPID );
-#           endif
-
-            FaGID = FaPID;
-         }
-
-//       father patch is a real patch
-         else if ( FaPID < amr->NPatchComma[FaLv][1] )
-            FaGID = FaPID + GID_Offset[FaLv];
-
-//       father patch is a buffer patch (only possible in LOAD_BALANCE)
-         else // (FaPID >= amr->NPatchComma[FaLv][1] )
-         {
-#           ifdef DEBUG_HDF5
-#           ifndef LOAD_BALANCE
-            Aux_Error( ERROR_INFO, "Lv %d, PID %d, FaPID %d >= NRealFaPatch %d (only possible in LOAD_BALANCE) !!\n",
-                       lv, PID, FaPID, amr->NPatchComma[FaLv][1] );
-#           endif
-
-            if ( FaPID >= amr->num[FaLv] )
-            Aux_Error( ERROR_INFO, "Lv %d, PID %d, FaPID %d >= total number of patches %d !!\n",
-                       lv, PID, FaPID, amr->num[FaLv] );
-#           endif // DEBUG_HDF5
-
-            FaLBIdx = amr->patch[0][FaLv][FaPID]->LB_Idx;
-
-            Mis_Matching_int( NPatchTotal[FaLv], LBIdxList_Sort[FaLv], 1, &FaLBIdx, &MatchIdx );
-
-#           ifdef DEBUG_HDF5
-            if ( MatchIdx < 0 )
-            Aux_Error( ERROR_INFO, "Lv %d, PID %d, FaPID %d, FaLBIdx %ld, couldn't find a matching patch !!\n",
-                       lv, PID, FaPID, FaLBIdx );
-#           endif
-
-            FaGID = LBIdxList_Sort_IdxTable[FaLv][MatchIdx] + GID_LvStart[FaLv];
-         } // if ( FaPID >= amr->NPatchComma[FaLv][1] )
-
-         FaList_Local[lv][PID] = FaGID;
-
-
-//       4-3-4. son GID
-         SonPID = amr->patch[0][lv][PID]->son;
-         SonLv  = lv + 1;
-
-//       no son (must check this first since SonLv may be out of range --> == NLEVEL)
-         if      ( SonPID == -1 )
-            SonGID = SonPID;
-
-//       son patch is a real patch at home
-         else if ( SonPID >= 0  &&  SonPID < amr->NPatchComma[SonLv][1] )
-            SonGID = SonPID + GID_Offset[SonLv];
-
-//       son patch lives abroad (only possible in LOAD_BALANCE)
-         else if ( SonPID < -1 )
-         {
-#           ifdef DEBUG_HDF5
-#           ifdef LOAD_BALANCE
-            const int SonRank = SON_OFFSET_LB - SonPID;
-            if ( SonRank < 0  ||  SonRank == MPI_Rank  ||  SonRank >= MPI_NRank )
-            Aux_Error( ERROR_INFO, "Lv %d, PID %d, SonPID %d, incorrect SonRank %d (MyRank %d, NRank %d) !!\n",
-                       lv, PID, SonPID, SonRank, MPI_Rank, MPI_NRank );
-#           else
-            Aux_Error( ERROR_INFO, "Lv %d, PID %d, SonPID %d < -1 (only possible in LOAD_BALANCE) !!\n",
-                       lv, PID, SonPID );
-#           endif // LOAD_BALANCE
-#           endif // DEBUG_HDF5
-
-//          get the SonGID by "father corner = son corner -> son LB_Idx -> son GID"
-//          --> didn't assume any relation between son's and father's LB_Idx
-//          (although for Hilbert curve we have "SonLBIdx-SonLBIdx%8 = 8*MyLBIdx")
-            SonCr    = amr->patch[0][lv][PID]->corner;
-            SonLBIdx = LB_Corner2Index( SonLv, SonCr, CHECK_ON );
-
-#           if ( defined DEBUG_HDF5  &&  LOAD_BALANCE == HILBERT )
-            if ( SonLBIdx - SonLBIdx%8 != 8*amr->patch[0][lv][PID]->LB_Idx )
-            Aux_Error( ERROR_INFO, "Lv %d, PID %d, SonPID %d, SonCr (%d,%d,%d), incorret SonLBIdx %ld, (MyLBIdx %ld) !!\n",
-                       lv, PID, SonPID, SonCr[0], SonCr[1], SonCr[2], SonLBIdx, amr->patch[0][lv][PID]->LB_Idx );
-#           endif
-
-            Mis_Matching_int( NPatchTotal[SonLv], LBIdxList_Sort[SonLv], 1, &SonLBIdx, &MatchIdx );
-
-#           ifdef DEBUG_HDF5
-            if ( MatchIdx < 0 )
-            Aux_Error( ERROR_INFO, "Lv %d, PID %d, SonPID %d, SonLBIdx %ld, couldn't find a matching patch !!\n",
-                       lv, PID, SonPID, SonLBIdx );
-#           endif
-
-            SonGID = LBIdxList_Sort_IdxTable[SonLv][MatchIdx] + GID_LvStart[SonLv];
-         } // else if ( SonPID < -1 )
-
-//       son patch is a buffer patch (SonPID >= amr->NPatchComma[SonLv][1]) --> impossible
-         else // ( SonPID >= amr->NPatchComma[SonLv][1] )
-            Aux_Error( ERROR_INFO, "Lv %d, PID %d, SonPID %d is a buffer patch (NRealSonPatch %d) !!\n",
-                       lv, PID, SonPID, amr->NPatchComma[SonLv][1] );
-
-         SonList_Local[lv][PID] = SonGID;
-
-
-//       4-3-5. sibling GID
-         for (int s=0; s<26; s++)
-         {
-            SibPID = amr->patch[0][lv][PID]->sibling[s];
-
-//          no sibling (SibPID can be either -1 or SIB_OFFSET_NONPERIODIC-BoundaryDirection)
-            if      ( SibPID < 0 )
-               SibGID = SibPID;
-
-//          sibling patch is a real patch
-            else if ( SibPID < amr->NPatchComma[lv][1] )
-               SibGID = SibPID + GID_Offset[lv];
-
-//          sibling patch is a buffer patch (which may lie outside the simulation domain)
-            else
-            {
-#              ifdef DEBUG_HDF5
-               if ( SibPID >= amr->num[lv] )
-               Aux_Error( ERROR_INFO, "Lv %d, PID %d, SibPID %d >= total number of patches %d !!\n",
-                          lv, PID, SibPID, amr->num[lv] );
-#              endif
-
-//             get the SibGID by "sibling corner -> sibling LB_Idx -> sibling GID"
-               SibCr    = amr->patch[0][lv][SibPID]->corner;
-               SibLBIdx = LB_Corner2Index( lv, SibCr, CHECK_OFF );   // periodicity has been assumed here
-
-               Mis_Matching_int( NPatchTotal[lv], LBIdxList_Sort[lv], 1, &SibLBIdx, &MatchIdx );
-
-#              ifdef DEBUG_HDF5
-               if ( MatchIdx < 0 )
-               Aux_Error( ERROR_INFO, "Lv %d, PID %d, SibPID %d, SibLBIdx %ld, couldn't find a matching patch !!\n",
-                          lv, PID, SibPID, SibLBIdx );
-#              endif
-
-               SibGID = LBIdxList_Sort_IdxTable[lv][MatchIdx] + GID_LvStart[lv];
-            } // if ( SibPID >= amr->NPatchComma[lv][1] )
-
-            SibList_Local[lv][PID][s] = SibGID;
-
-         } // for (int s=0; s<26; s++)
-
-
-#        ifdef PARTICLE
-//       4-3-6. NPar
-         NParList_Local[lv][PID] = amr->patch[0][lv][PID]->NPar;
-#        endif
-      } // for (int PID=0; PID<amr->NPatchComma[lv][1]; PID++)
-   } // for (int lv=0; lv<NLEVEL; lv++)
-
+   LB_FillLocalPatchExchangeList(pc, lel);
 
 // 4-4. gather data from all ranks
-   for (int lv=0; lv<NLEVEL; lv++)
-   {
-      for (int r=0; r<MPI_NRank; r++)
-      {
-         RecvCount_Fa  [r] = NPatchAllRank[r][lv];
-         RecvCount_Son [r] = RecvCount_Fa[r];
-         RecvCount_Sib [r] = RecvCount_Fa[r]*26;
-         RecvCount_Cr  [r] = RecvCount_Fa[r]*3;
-#        ifdef PARTICLE
-         RecvCount_NPar[r] = RecvCount_Fa[r];
-#        endif
-
-         RecvDisp_Fa   [r] = ( r == 0 ) ? 0 : RecvDisp_Fa[r-1] + RecvCount_Fa[r-1];
-         RecvDisp_Son  [r] = RecvDisp_Fa[r];
-         RecvDisp_Sib  [r] = RecvDisp_Fa[r]*26;
-         RecvDisp_Cr   [r] = RecvDisp_Fa[r]*3;
-#        ifdef PARTICLE
-         RecvDisp_NPar [r] = RecvDisp_Fa[r];
-#        endif
-      }
-
-//    note that we collect data at one level at a time
-      MPI_Gatherv( FaList_Local[lv],     amr->NPatchComma[lv][1],    MPI_INT,
-                   FaList_AllLv+GID_LvStart[lv],       RecvCount_Fa,   RecvDisp_Fa,   MPI_INT, 0, MPI_COMM_WORLD );
-
-      MPI_Gatherv( SonList_Local[lv],    amr->NPatchComma[lv][1],    MPI_INT,
-                   SonList_AllLv+GID_LvStart[lv],      RecvCount_Son,  RecvDisp_Son,  MPI_INT, 0, MPI_COMM_WORLD );
-
-      MPI_Gatherv( SibList_Local[lv][0], amr->NPatchComma[lv][1]*26, MPI_INT,
-                   (SibList_AllLv+GID_LvStart[lv])[0], RecvCount_Sib,  RecvDisp_Sib,  MPI_INT, 0, MPI_COMM_WORLD );
-
-      MPI_Gatherv( CrList_Local[lv][0],  amr->NPatchComma[lv][1]*3,  MPI_INT,
-                   (CrList_AllLv+GID_LvStart[lv])[0],  RecvCount_Cr,   RecvDisp_Cr,   MPI_INT, 0, MPI_COMM_WORLD );
-
-#     ifdef PARTICLE
-      MPI_Gatherv( NParList_Local[lv],    amr->NPatchComma[lv][1],    MPI_INT,
-                   NParList_AllLv+GID_LvStart[lv],     RecvCount_NPar, RecvDisp_NPar, MPI_INT, 0, MPI_COMM_WORLD );
-#     endif
-   } // for (int lv=0; lv<NLEVEL; lv++)
-
+   LB_FillGlobalPatchExchangeList(pc, lel, gel, root);
 
 // 4-5. dump the tree info
    if ( MPI_Rank == 0 )
@@ -766,19 +464,19 @@ void Output_DumpData_Total_HDF5( const char *FileName )
       if ( H5_GroupID_Tree < 0 )    Aux_Error( ERROR_INFO, "failed to create the group \"%s\" !!\n", "Tree" );
 
 //    4-5-1. LBIdx
-      H5_SetDims_LBIdx = NPatchAllLv;
+      H5_SetDims_LBIdx = pc.NPatchAllLv;
       H5_SpaceID_LBIdx = H5Screate_simple( 1, &H5_SetDims_LBIdx, NULL );
       H5_SetID_LBIdx   = H5Dcreate( H5_GroupID_Tree, "LBIdx", H5T_NATIVE_LONG, H5_SpaceID_LBIdx,
                                     H5P_DEFAULT, H5_DataCreatePropList, H5P_DEFAULT );
 
       if ( H5_SetID_LBIdx < 0 )  Aux_Error( ERROR_INFO, "failed to create the dataset \"%s\" !!\n", "LBIdx" );
 
-      H5_Status = H5Dwrite( H5_SetID_LBIdx, H5T_NATIVE_LONG, H5S_ALL, H5S_ALL, H5P_DEFAULT, LBIdxList_AllLv );
+      H5_Status = H5Dwrite( H5_SetID_LBIdx, H5T_NATIVE_LONG, H5S_ALL, H5S_ALL, H5P_DEFAULT, gel.LBIdxList_AllLv );
       H5_Status = H5Dclose( H5_SetID_LBIdx );
       H5_Status = H5Sclose( H5_SpaceID_LBIdx );
 
 //    4-5-2. corner
-      H5_SetDims_Cr[0] = NPatchAllLv;
+      H5_SetDims_Cr[0] = pc.NPatchAllLv;
       H5_SetDims_Cr[1] = 3;
       H5_SpaceID_Cr    = H5Screate_simple( 2, H5_SetDims_Cr, NULL );
       H5_SetID_Cr      = H5Dcreate( H5_GroupID_Tree, "Corner", H5T_NATIVE_INT, H5_SpaceID_Cr,
@@ -795,36 +493,36 @@ void Output_DumpData_Total_HDF5( const char *FileName )
       H5_Status = H5Awrite( H5_AttID_Cvt2Phy, H5T_NATIVE_DOUBLE, &amr->dh[TOP_LEVEL] );
       H5_Status = H5Aclose( H5_AttID_Cvt2Phy );
 
-      H5_Status = H5Dwrite( H5_SetID_Cr, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, CrList_AllLv );
+      H5_Status = H5Dwrite( H5_SetID_Cr, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, gel.CrList_AllLv );
       H5_Status = H5Dclose( H5_SetID_Cr );
       H5_Status = H5Sclose( H5_SpaceID_Cr );
 
 //    4-5-3. father
-      H5_SetDims_Fa = NPatchAllLv;
+      H5_SetDims_Fa = pc.NPatchAllLv;
       H5_SpaceID_Fa = H5Screate_simple( 1, &H5_SetDims_Fa, NULL );
       H5_SetID_Fa   = H5Dcreate( H5_GroupID_Tree, "Father", H5T_NATIVE_INT, H5_SpaceID_Fa,
                                  H5P_DEFAULT, H5_DataCreatePropList, H5P_DEFAULT );
 
       if ( H5_SetID_Fa < 0 )  Aux_Error( ERROR_INFO, "failed to create the dataset \"%s\" !!\n", "Father" );
 
-      H5_Status = H5Dwrite( H5_SetID_Fa, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, FaList_AllLv );
+      H5_Status = H5Dwrite( H5_SetID_Fa, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, gel.FaList_AllLv );
       H5_Status = H5Dclose( H5_SetID_Fa );
       H5_Status = H5Sclose( H5_SpaceID_Fa );
 
 //    4-5-4. son
-      H5_SetDims_Son = NPatchAllLv;
+      H5_SetDims_Son = pc.NPatchAllLv;
       H5_SpaceID_Son = H5Screate_simple( 1, &H5_SetDims_Son, NULL );
       H5_SetID_Son   = H5Dcreate( H5_GroupID_Tree, "Son", H5T_NATIVE_INT, H5_SpaceID_Son,
                                   H5P_DEFAULT, H5_DataCreatePropList, H5P_DEFAULT );
 
       if ( H5_SetID_Son < 0 )  Aux_Error( ERROR_INFO, "failed to create the dataset \"%s\" !!\n", "Son" );
 
-      H5_Status = H5Dwrite( H5_SetID_Son, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, SonList_AllLv );
+      H5_Status = H5Dwrite( H5_SetID_Son, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, gel.SonList_AllLv );
       H5_Status = H5Dclose( H5_SetID_Son );
       H5_Status = H5Sclose( H5_SpaceID_Son );
 
 //    4-5-5. sibling
-      H5_SetDims_Sib[0] = NPatchAllLv;
+      H5_SetDims_Sib[0] = pc.NPatchAllLv;
       H5_SetDims_Sib[1] = 26;
       H5_SpaceID_Sib    = H5Screate_simple( 2, H5_SetDims_Sib, NULL );
       H5_SetID_Sib      = H5Dcreate( H5_GroupID_Tree, "Sibling", H5T_NATIVE_INT, H5_SpaceID_Sib,
@@ -832,20 +530,20 @@ void Output_DumpData_Total_HDF5( const char *FileName )
 
       if ( H5_SetID_Sib < 0 )    Aux_Error( ERROR_INFO, "failed to create the dataset \"%s\" !!\n", "Sibling" );
 
-      H5_Status = H5Dwrite( H5_SetID_Sib, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, SibList_AllLv );
+      H5_Status = H5Dwrite( H5_SetID_Sib, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, gel.SibList_AllLv );
       H5_Status = H5Dclose( H5_SetID_Sib );
       H5_Status = H5Sclose( H5_SpaceID_Sib );
 
 //    4-5-6. NPar
 #     ifdef PARTICLE
-      H5_SetDims_NPar = NPatchAllLv;
+      H5_SetDims_NPar = pc.NPatchAllLv;
       H5_SpaceID_NPar = H5Screate_simple( 1, &H5_SetDims_NPar, NULL );
       H5_SetID_NPar   = H5Dcreate( H5_GroupID_Tree, "NPar", H5T_NATIVE_INT, H5_SpaceID_NPar,
                                    H5P_DEFAULT, H5_DataCreatePropList, H5P_DEFAULT );
 
       if ( H5_SetID_NPar < 0 )   Aux_Error( ERROR_INFO, "failed to create the dataset \"%s\" !!\n", "NPar" );
 
-      H5_Status = H5Dwrite( H5_SetID_NPar, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, NParList_AllLv );
+      H5_Status = H5Dwrite( H5_SetID_NPar, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, gel.NParList_AllLv );
       H5_Status = H5Dclose( H5_SetID_NPar );
       H5_Status = H5Sclose( H5_SpaceID_NPar );
 #     endif
@@ -867,7 +565,7 @@ void Output_DumpData_Total_HDF5( const char *FileName )
 #  endif
 
 // 5-1. initialize the "GridData" group and the datasets of all fields and magnetic field
-   H5_SetDims_Field[0] = NPatchAllLv;
+   H5_SetDims_Field[0] = pc.NPatchAllLv;
    H5_SetDims_Field[1] = PS1;
    H5_SetDims_Field[2] = PS1;
    H5_SetDims_Field[3] = PS1;
@@ -878,7 +576,7 @@ void Output_DumpData_Total_HDF5( const char *FileName )
 #  ifdef MHD
    for (int v=0; v<NCOMP_MAG; v++)
    {
-      H5_SetDims_FCMag[0] = NPatchAllLv;
+      H5_SetDims_FCMag[0] = pc.NPatchAllLv;
       for (int t=1; t<4; t++)
       H5_SetDims_FCMag[t] = ( 3-t == v ) ? PS1P1 : PS1;
 
@@ -1010,7 +708,7 @@ void Output_DumpData_Total_HDF5( const char *FileName )
 
 
 //          5-2-1-2. determine the subset of the dataspace
-            H5_Offset_Field[0] = GID_Offset[lv];
+            H5_Offset_Field[0] = pc.GID_Offset[lv];
             H5_Offset_Field[1] = 0;
             H5_Offset_Field[2] = 0;
             H5_Offset_Field[3] = 0;
@@ -1365,7 +1063,7 @@ void Output_DumpData_Total_HDF5( const char *FileName )
 
 
 //             5-2-2-2. determine the subset of the dataspace
-               H5_Offset_FCMag[0] = GID_Offset[lv];
+               H5_Offset_FCMag[0] = pc.GID_Offset[lv];
                H5_Offset_FCMag[1] = 0;
                H5_Offset_FCMag[2] = 0;
                H5_Offset_FCMag[3] = 0;
@@ -1590,7 +1288,7 @@ void Output_DumpData_Total_HDF5( const char *FileName )
 
       if ( H5_SetID_Fa < 0 )  Aux_Error( ERROR_INFO, "failed to open the dataset \"%s\" !!\n", SetName );
 
-      H5_Status = H5Dread( H5_SetID_Fa, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, FaList_AllLv );
+      H5_Status = H5Dread( H5_SetID_Fa, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, gel.FaList_AllLv );
       H5_Status = H5Dclose( H5_SetID_Fa );
 
       sprintf( SetName, "Tree/Son" );
@@ -1598,7 +1296,7 @@ void Output_DumpData_Total_HDF5( const char *FileName )
 
       if ( H5_SetID_Son < 0 )  Aux_Error( ERROR_INFO, "failed to open the dataset \"%s\" !!\n", SetName );
 
-      H5_Status = H5Dread( H5_SetID_Son, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, SonList_AllLv );
+      H5_Status = H5Dread( H5_SetID_Son, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, gel.SonList_AllLv );
       H5_Status = H5Dclose( H5_SetID_Son );
 
       sprintf( SetName, "Tree/Sibling" );
@@ -1606,32 +1304,32 @@ void Output_DumpData_Total_HDF5( const char *FileName )
 
       if ( H5_SetID_Sib < 0 )  Aux_Error( ERROR_INFO, "failed to open the dataset \"%s\" !!\n", SetName );
 
-      H5_Status = H5Dread( H5_SetID_Sib, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, SibList_AllLv );
+      H5_Status = H5Dread( H5_SetID_Sib, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, gel.SibList_AllLv );
       H5_Status = H5Dclose( H5_SetID_Sib );
 
 
       for (int lv=0; lv<NLEVEL; lv++)
-      for (int GID=GID_LvStart[lv]; GID<GID_LvStart[lv]+NPatchTotal[lv]; GID++)
+      for (int GID=pc.GID_LvStart[lv]; GID<pc.GID_LvStart[lv]+NPatchTotal[lv]; GID++)
       {
 //       7-1-2. root patches have no father
          if ( lv == 0 )
-         if ( FaList_AllLv[GID] != -1 )
-            Aux_Error( ERROR_INFO, "Lv %d, GID %d, FaGID %d != -1 !!\n", lv, GID, FaList_AllLv[GID] );
+         if ( gel.FaList_AllLv[GID] != -1 )
+            Aux_Error( ERROR_INFO, "Lv %d, GID %d, FaGID %d != -1 !!\n", lv, GID, gel.FaList_AllLv[GID] );
 
 //       7-1-3. all patches at refinement levels have fathers
          if ( lv > 0 )
-         if ( FaList_AllLv[GID] < 0  ||  FaList_AllLv[GID] >= GID_LvStart[lv] )
+         if ( gel.FaList_AllLv[GID] < 0  ||  gel.FaList_AllLv[GID] >= pc.GID_LvStart[lv] )
             Aux_Error( ERROR_INFO, "Lv %d, GID %d, FaGID %d < 0 (or > max = %d) !!\n",
-                       lv, GID, FaList_AllLv[GID], GID_LvStart[lv]-1 );
+                       lv, GID, gel.FaList_AllLv[GID], pc.GID_LvStart[lv]-1 );
 
 //       7-1-4. father->son == itself
          if ( lv > 0 )
-         if ( SonList_AllLv[ FaList_AllLv[GID] ] + GID%8 != GID )
+         if ( gel.SonList_AllLv[ gel.FaList_AllLv[GID] ] + GID%8 != GID )
             Aux_Error( ERROR_INFO, "Lv %d, GID %d, FaGID %d, FaGID->Son %d ==> inconsistent !!\n",
-                       lv, GID, FaList_AllLv[GID], SonList_AllLv[ FaList_AllLv[GID] ] );
+                       lv, GID, gel.FaList_AllLv[GID], gel.SonList_AllLv[ gel.FaList_AllLv[GID] ] );
 
 //       7-1-5. son->father == itself
-         SonGID = SonList_AllLv[GID];
+         SonGID = gel.SonList_AllLv[GID];
          if ( SonGID != -1 )
          {
             if ( lv >= MAX_LEVEL )
@@ -1640,30 +1338,30 @@ void Output_DumpData_Total_HDF5( const char *FileName )
             if ( SonGID < -1 )
                Aux_Error( ERROR_INFO, "Lv %d, GID %d, SonGID %d < -1 !!\n", lv, GID, SonGID );
 
-            if ( lv < NLEVEL-1  &&  SonGID >= GID_LvStart[lv+1]+NPatchTotal[lv+1] )
+            if ( lv < NLEVEL-1  &&  SonGID >= pc.GID_LvStart[lv+1]+NPatchTotal[lv+1] )
                Aux_Error( ERROR_INFO, "Lv %d, GID %d, SonGID %d > max %d !!\n", lv, GID, SonGID,
-                          GID_LvStart[lv+1]+NPatchTotal[lv+1]-1 );
+                          pc.GID_LvStart[lv+1]+NPatchTotal[lv+1]-1 );
 
             for (int LocalID=0; LocalID<8; LocalID++)
-            if ( FaList_AllLv[SonGID+LocalID] != GID )
+            if ( gel.FaList_AllLv[SonGID+LocalID] != GID )
                Aux_Error( ERROR_INFO, "Lv %d, GID %d, SonGID %d, SonGID->Father %d ==> inconsistent !!\n",
-                          lv, GID, SonGID+LocalID, FaList_AllLv[SonGID+LocalID] );
+                          lv, GID, SonGID+LocalID, gel.FaList_AllLv[SonGID+LocalID] );
          }
 
 //       7-1-6. sibling->sibling_mirror = itself
          for (int s=0; s<26; s++)
          {
-            SibGID = SibList_AllLv[GID][s];
+            SibGID = gel.SibList_AllLv[GID][s];
 
             if ( SibGID >= 0 )
             {
-               if ( SibGID < GID_LvStart[lv]  ||  SibGID >= GID_LvStart[lv]+NPatchTotal[lv] )
+               if ( SibGID < pc.GID_LvStart[lv]  ||  SibGID >= pc.GID_LvStart[lv]+NPatchTotal[lv] )
                   Aux_Error( ERROR_INFO, "Lv %d, GID %d, sib %d, SibGID %d lies outside the correct range (%d <= SibGID < %d) !!\n",
-                             lv, GID, s, SibGID, GID_LvStart[lv], GID_LvStart[lv]+NPatchTotal[lv] );
+                             lv, GID, s, SibGID, pc.GID_LvStart[lv], pc.GID_LvStart[lv]+NPatchTotal[lv] );
 
-               if ( SibList_AllLv[SibGID][ MirrorSib[s] ] != GID )
+               if ( gel.SibList_AllLv[SibGID][ MirrorSib[s] ] != GID )
                   Aux_Error( ERROR_INFO, "Lv %d, GID %d, sib %d, SibGID %d != SibGID->sibling %d !!\n",
-                             lv, GID, s, SibGID, SibList_AllLv[SibGID][ MirrorSib[s] ] );
+                             lv, GID, s, SibGID, gel.SibList_AllLv[SibGID][ MirrorSib[s] ] );
             }
          }
       } // for (int lv=0; lv<NLEVEL; lv++)
@@ -1681,36 +1379,6 @@ void Output_DumpData_Total_HDF5( const char *FileName )
    H5_Status = H5Tclose( H5_TypeID_Com_InputPara );
    H5_Status = H5Sclose( H5_SpaceID_Scalar );
    H5_Status = H5Pclose( H5_DataCreatePropList );
-
-   delete [] NPatchAllRank;
-
-   if ( MPI_Rank == 0 )
-   {
-      delete [] LBIdxList_AllLv;
-      delete []    CrList_AllLv;
-      delete []    FaList_AllLv;
-      delete []   SonList_AllLv;
-      delete []   SibList_AllLv;
-#     ifdef PARTICLE
-      delete []  NParList_AllLv;
-#     endif
-   }
-
-   for (int lv=0; lv<NLEVEL; lv++)
-   {
-      delete [] LBIdxList_Local[lv];
-      delete []    CrList_Local[lv];
-      delete []    FaList_Local[lv];
-      delete []   SonList_Local[lv];
-      delete []   SibList_Local[lv];
-#     ifdef PARTICLE
-      delete []  NParList_Local[lv];
-#     endif
-
-      delete [] LBIdxList_Sort[lv];
-      delete [] LBIdxList_Sort_IdxTable[lv];
-   }
-
 
    if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s (DumpID = %d)     ... done\n", __FUNCTION__, DumpID );
 

--- a/src/YT/YT_AddLocalGrid.cpp
+++ b/src/YT/YT_AddLocalGrid.cpp
@@ -10,14 +10,13 @@
 //                2. Invoked by YT_Inline().
 //                3. FieldList is used by MHD field, since it needs to load dimensions to yt_field.
 //
-// Parameter   :  GID_LvStart   : Glocal patch index that this level starts at
-//                NPatchAllRank : Number of patches in [MPI rank][level]
-//                NField        : Number of fields loaded to YT.
+// Parameter   :  NField        : Number of fields loaded to YT.
 //                FieldList     : List of field_name, field_define_type.
+//                pc            : Patch count object with information about the number of patches on all ranks
 //
 // Return      :  None
 //-------------------------------------------------------------------------------------------------------
-void YT_AddLocalGrid( const int *GID_LvStart, const int (*NPatchAllRank)[NLEVEL], int NField, yt_field *FieldList)
+void YT_AddLocalGrid( int NField, yt_field *FieldList, LB_PatchCount& pc)
 {
 
    if ( OPT__VERBOSE  &&  MPI_Rank == 0 )    Aux_Message( stdout, "%s ...\n", __FUNCTION__ );
@@ -29,36 +28,11 @@ void YT_AddLocalGrid( const int *GID_LvStart, const int (*NPatchAllRank)[NLEVEL]
 // record local grids index and patched grids index if LIBYT_USE_PATCH_GROUP
    int LID = 0;
 
-// get the search table, needed by parent_id
-   int   RecvCount_LBIdx[MPI_NRank], RecvDisp_LBIdx[MPI_NRank];
-   long *LBIdxList_Sort[NLEVEL], *LBIdxList_Local[NLEVEL];
-   int  *LBIdxList_Sort_IdxTable[NLEVEL];
+   LB_LocalPatchExchangeList lel; 
 
-   for (int lv=0; lv<NLEVEL; lv++)
-   {
-      LBIdxList_Local        [lv] = new long [ amr->NPatchComma[lv][1] ];
-      LBIdxList_Sort         [lv] = new long [ NPatchTotal[lv] ];
-      LBIdxList_Sort_IdxTable[lv] = new int  [ NPatchTotal[lv] ];
-   }
-
-   for (int lv=0; lv<NLEVEL; lv++)
-   {
-      for (int r=0; r<MPI_NRank; r++)
-      {
-         RecvCount_LBIdx[r] = NPatchAllRank[r][lv];
-         RecvDisp_LBIdx [r] = ( r == 0 ) ? 0 : RecvDisp_LBIdx[r-1] + RecvCount_LBIdx[r-1];
-      }
-
-      for (int PID=0; PID<amr->NPatchComma[lv][1]; PID++)
-         LBIdxList_Local[lv][PID] = amr->patch[0][lv][PID]->LB_Idx;
-
-      MPI_Allgatherv( LBIdxList_Local[lv], amr->NPatchComma[lv][1], MPI_LONG,
-                      LBIdxList_Sort[lv], RecvCount_LBIdx, RecvDisp_LBIdx, MPI_LONG,
-                      MPI_COMM_WORLD );
-   }
-
-   for (int lv=0; lv<NLEVEL; lv++)
-      Mis_Heapsort( NPatchTotal[lv], LBIdxList_Sort[lv], LBIdxList_Sort_IdxTable[lv] );
+// sync load balance ids 
+   LB_AllgatherLBIdx(pc, lel);
+   LB_FillLocalPatchExchangeList(pc, lel); 
 
 // loop over local patches at all levels
    for (int lv=0; lv<NLEVEL; lv++)
@@ -68,7 +42,6 @@ void YT_AddLocalGrid( const int *GID_LvStart, const int (*NPatchAllRank)[NLEVEL]
 #     ifdef GRAVITY
       const int PotSg = amr->PotSg[lv];
 #     endif
-
 #     ifdef MHD
       const int MagSg = amr->MagSg[lv];
 #     endif
@@ -79,7 +52,7 @@ void YT_AddLocalGrid( const int *GID_LvStart, const int (*NPatchAllRank)[NLEVEL]
       for (int PID=0; PID<(amr->NPatchComma[lv][1]); PID++)
 #     endif // #ifdef LIBYT_USE_PATCH_GROUP
       {
-         const int GID = PID + YT_GID_Offset[lv];
+         const long GID = PID + pc.GID_Offset[lv];
 
          for (int d=0; d<3; d++)
          {
@@ -117,55 +90,13 @@ void YT_AddLocalGrid( const int *GID_LvStart, const int (*NPatchAllRank)[NLEVEL]
          YT_Grids[LID].level  = lv;
 
          // getting parent's id
-         int FaPID = amr->patch[0][lv][PID]->father;
-         int FaLv = lv - 1;
+         long FaGID = lel.FaList_Local[lv][PID];
 
-         if ( FaPID < 0 ){
-            // no father (only possible for the root patches)
-#           ifdef DEBUG_HDF5
-            if ( lv != 0 )       Aux_Error( ERROR_INFO, "Lv %d, PID %d, FaPID %d < 0 !!\n", lv, PID, FaPID );
-            if ( FaPID != -1 )   Aux_Error( ERROR_INFO, "Lv %d, PID %d, FaPID %d < 0 but != -1 !!\n", lv, PID, FaPID );
-#           endif
-            YT_Grids[LID].parent_id = -1;
-         }
-         else if ( FaPID < (amr->NPatchComma[FaLv][1]) ){
-            // has father patch
-#           ifdef LIBYT_USE_PATCH_GROUP
-            YT_Grids[LID].parent_id = (long) (FaPID + YT_GID_Offset[FaLv]) / 8;
-#           else
-            YT_Grids[LID].parent_id = (long) (FaPID + YT_GID_Offset[FaLv]);
-#           endif // #ifdef LIBYT_USE_PATCH_GROUP
-         }
-         else{
-            // father patch is a buffer patch (only possible in LOAD_BALANCE)
-#           ifdef DEBUG_HDF5
-#           ifndef LOAD_BALANCE
-            Aux_Error( ERROR_INFO, "Lv %d, PID %d, FaPID %d >= NRealFaPatch %d (only possible in LOAD_BALANCE) !!\n",
-                       lv, PID, FaPID, amr->NPatchComma[FaLv][1] );
-#           endif
-            if ( FaPID >= (amr->num[FaLv]) ){
-                Aux_Error( ERROR_INFO, "Lv %d, PID %d, FaPID %d >= total number of patches %d !!\n",
-                           lv, PID, FaPID, amr->num[FaLv] );
-            }
-#           endif // DEBUG_HDF5
+#        ifdef LIBYT_USE_PATCH_GROUP
+         if ( FaGID != -1 ) FaGID = (long) (FaGID / 8); 
+#        endif // #ifdef LIBYT_USE_PATCH_GROUP
 
-            long FaLBIdx = amr->patch[0][FaLv][FaPID]->LB_Idx;
-            int MatchIdx;
-            Mis_Matching_int( NPatchTotal[FaLv], LBIdxList_Sort[FaLv], 1, &FaLBIdx, &MatchIdx );
-
-#           ifdef DEBUG_HDF5
-            if ( MatchIdx < 0 ){
-                Aux_Error( ERROR_INFO, "Lv %d, PID %d, FaPID %d, FaLBIdx %ld, couldn't find a matching patch !!\n",
-                           lv, PID, FaPID, FaLBIdx );
-            }
-#           endif
-
-#           ifdef LIBYT_USE_PATCH_GROUP
-            YT_Grids[LID].parent_id = (long) (LBIdxList_Sort_IdxTable[FaLv][MatchIdx] + GID_LvStart[FaLv]) / 8;
-#           else
-            YT_Grids[LID].parent_id = (long) (LBIdxList_Sort_IdxTable[FaLv][MatchIdx] + GID_LvStart[FaLv]);
-#           endif // #ifdef LIBYT_USE_PATCH_GROUP
-         }
+         YT_Grids[LID].parent_id = FaGID;
 
 #        ifndef LIBYT_USE_PATCH_GROUP
          // load patch data to libyt if not use LIBYT_USE_PATCH_GROUP
@@ -221,14 +152,6 @@ void YT_AddLocalGrid( const int *GID_LvStart, const int (*NPatchAllRank)[NLEVEL]
 
          LID = LID + 1;
       }
-   }
-
-   // free resources
-   for (int lv=0; lv<NLEVEL; lv++)
-   {
-      delete [] LBIdxList_Local        [lv];
-      delete [] LBIdxList_Sort         [lv];
-      delete [] LBIdxList_Sort_IdxTable[lv];
    }
 
    if ( yt_commit_grids( ) != YT_SUCCESS )  Aux_Error( ERROR_INFO, "yt_commit_grids() failed !!\n" );

--- a/src/YT/YT_Inline.cpp
+++ b/src/YT/YT_Inline.cpp
@@ -4,7 +4,7 @@
 
 // call libyt API
 void YT_SetParameter( const int NPatchAllLv, const int NField, const int NPatchLocalLv);
-void YT_AddLocalGrid( const int *GID_LvStart, const int (*NPatchAllRank)[NLEVEL], int NField, yt_field *FieldList);
+void YT_AddLocalGrid( int NField, yt_field *FieldList, LB_PatchCount& pc);
 
 #ifdef LIBYT_USE_PATCH_GROUP
 
@@ -55,34 +55,17 @@ void YT_Inline()
 
    if ( OPT__VERBOSE  &&  MPI_Rank == 0 )    Aux_Message( stdout, "%s ...\n", __FUNCTION__ );
 
+   LB_PatchCount pc;
+   
+// 1. get patch counts per level and per rank from all ranks
+   LB_AllgatherPatchCount(pc); 
+   
 
-// 1. gather the number of patches at different MPI ranks, calculate number of local patches
-//    and set the corresponding GID offset
-   int (*NPatchAllRank)[NLEVEL] = new int [MPI_NRank][NLEVEL];
-   int NPatchLocal[NLEVEL], NPatchAllLv=0, NPatchLocalLv=0, GID_LvStart[NLEVEL];
-
+// set YT_GID_Offset for searching GID in derived function and particle get attribute function.
    for (int lv=0; lv<NLEVEL; lv++)
    {
-      NPatchLocal[lv] = amr->NPatchComma[lv][1];
-      NPatchLocalLv = NPatchLocalLv + NPatchLocal[lv];
+      YT_GID_Offset[lv] = pc.GID_Offset[lv];
    }
-
-   MPI_Allgather( NPatchLocal, NLEVEL, MPI_INT, NPatchAllRank[0], NLEVEL, MPI_INT, MPI_COMM_WORLD );
-
-   for (int lv=0; lv<NLEVEL; lv++)
-   {
-      // set YT_GID_Offset for searching GID in derived function and particle get attribute function.
-      YT_GID_Offset[lv] = 0;
-
-      for (int r=0; r<MPI_Rank; r++)      YT_GID_Offset[lv] += NPatchAllRank[r][lv];
-
-      for (int FaLv=0; FaLv<lv; FaLv++)   YT_GID_Offset[lv] += NPatchTotal[FaLv];
-
-      NPatchAllLv += NPatchTotal[lv];
-
-      GID_LvStart[lv] = ( lv == 0 ) ? 0 : GID_LvStart[lv-1] + NPatchTotal[lv-1];
-   }
-
 
 // 2. prepare YT-specific parameters
 // 2-1. determine the number of fields
@@ -109,7 +92,7 @@ void YT_Inline()
 #  endif
 
 // 2-2. Call YT_SetParameter and set particle info if need.
-   YT_SetParameter( NPatchAllLv, NField, NPatchLocalLv);
+   YT_SetParameter( pc.NPatchAllLv, NField, pc.NPatchLocalLv);
 
 // 3.   Get FieldList and ParticleList, fill the info if needed
 // 3-1. get yt_field array FieldList, and filled in field info
@@ -259,15 +242,14 @@ void YT_Inline()
 #  endif // #ifdef PARTICLE
 
 // 4. prepare local patches for libyt
-   YT_AddLocalGrid( GID_LvStart, NPatchAllRank, NField, FieldList);
+   YT_AddLocalGrid( NField, FieldList, pc);
 
 // 5. perform yt inline analysis
-   if ( yt_inline_argument( "yt_inline_inputArg", 1, "\'Dens\'" ) != YT_SUCCESS )    Aux_Error( ERROR_INFO, "yt_inline_inputArg() failed !!\n" );
+   if ( yt_inline_argument( "yt_inline_inputArg", 1, "\'density\'" ) != YT_SUCCESS )    Aux_Error( ERROR_INFO, "yt_inline_inputArg() failed !!\n" );
    if ( yt_inline( "yt_inline" ) != YT_SUCCESS )     Aux_Error( ERROR_INFO, "yt_inline() failed !!\n" );
 
 // 6. free resource
    if ( yt_free_gridsPtr() != YT_SUCCESS )    Aux_Error( ERROR_INFO, "yt_free_gridsPtr() failed !!\n" );
-   delete [] NPatchAllRank;
 
    if ( OPT__VERBOSE  &&  MPI_Rank == 0 )    Aux_Message( stdout, "%s ... done\n", __FUNCTION__ );
 

--- a/src/YT/YT_Miscellaneous.cpp
+++ b/src/YT/YT_Miscellaneous.cpp
@@ -8,6 +8,7 @@
 //
 // Note        :  1. Get YT passed in gid, and then write its corresponding level and PID at *level and *PID.
 //                2. Whether or not using LIBYT_USE_PATCH_GROUP would work.
+//                3. The global variable YT_GID_Offset must be filled with values before calling YT_GetPID
 //
 // Parameter   :  gid      : gid YT passed in.
 //                level    : fill in level of this gid.
@@ -15,26 +16,11 @@
 //
 // Return      :  *level, *PID
 //-------------------------------------------------------------------------------------------------------
-void YT_GetPID(const long gid, int *level, int *PID){
-#ifdef GAMER_DEBUG
-    long NPatchAllLv = 0;
-    for (int lv=0; lv<NLEVEL; lv++)  NPatchAllLv += NPatchTotal[lv];
-    if ( gid < 0  ||  gid >= NPatchAllLv )  Aux_Error( ERROR_INFO, "incorrect gid %ld (max = %ld) !!\n", gid, NPatchAllLv-1 );
-#endif
-    *level = 0;
-    for(int lv=1; lv<NLEVEL; lv++){
-#ifdef  LIBYT_USE_PATCH_GROUP
-        if( gid < (YT_GID_Offset[lv] / 8) ) break;
-#else
-        if( gid <  YT_GID_Offset[lv] )      break;
-#endif // #ifdef  LIBYT_USE_PATCH_GROUP
-        *level = lv;
-    }
-#ifdef LIBYT_USE_PATCH_GROUP
-    *PID = gid * 8 - YT_GID_Offset[*level];
-#else
-    *PID = gid - YT_GID_Offset[*level];
-#endif // #ifdef  LIBYT_USE_PATCH_GROUP
+void YT_GetPID(const long gid, int *level, int *PID) {
+#   ifdef  LIBYT_USE_PATCH_GROUP
+    LB_GetPID( 8 * gid, *level, *PID, YT_GID_Offset ); 
+#   else
+    LB_GetPID(     gid, *level, *PID, YT_GID_Offset );
+#   endif // # ifdef  LIBYT_USE_PATCH_GROUP
 }
-
 #endif // #ifdef SUPPORT_LIBYT


### PR DESCRIPTION
# Move functions gathering AMR tree to separate location
This pull request moves the functions for synchronising the patch counts and the load balancing ID's between different ranks as well as the functions for calculating the GIDs of father, son and sibling patches the new source file `LB_GatherTree.cpp`. 
The corresponding structures are defined in `patch.h`, but can be moved to a more appropriate header file if necessary. 
The pull request further modifies the code for storing the HDF5 file and the YT inline analysis in order to reduce code redundancy. 
In addition, it provides a function that generates a flat tree structure `LB_GlobalPatch global_tree[NPatchAllLv]` where
```
struct LB_GlobalPatch
{
   int    corner[3];
   long    sibling[26];
   long    father;
   long    son;
   long   LB_Idx;
   int    level; 
#  ifdef PARTICLE
   int    NPar;
#  endif 
}; // struct LB_GlobalPatch
```
stores the corresponding GIDs of sibling, father and son patches and a patch with a given GID can be retrieved as `global_tree[GID]`. The tree can either be distributed to all ranks (Allgather) or to the root rank (Gather). 
The code was tested in `HYDRO` and `ELBDM` in `SERIAL` mode and with `LOAD_BALANCING` and OpenMP. 
Both the HDF5 files and the YT inline analysis seem to work correctly. 
