### PR TITLE
Bugfix for evolution time-step from the lighbulb scheme

### DIFF
--- a/include/Field.h
+++ b/include/Field.h
@@ -25,7 +25,7 @@ SET_GLOBAL( FieldIdx_t Idx_MomZ,          Idx_Undefined );
 SET_GLOBAL( FieldIdx_t Idx_Engy,          Idx_Undefined );
 #if ( EOS == EOS_NUCLEAR )
 SET_GLOBAL( FieldIdx_t Idx_Ye,            Idx_Undefined );
-SET_GLOBAL( FieldIdx_t Idx_dEdt_LB,       Idx_Undefined );
+SET_GLOBAL( FieldIdx_t Idx_dEdt_Nu,       Idx_Undefined );
 #if ( NUC_TABLE_MODE == NUC_TABLE_MODE_TEMP )
 SET_GLOBAL( FieldIdx_t Idx_Temp_IG,       Idx_Undefined );
 #endif

--- a/include/Macro.h
+++ b/include/Macro.h
@@ -961,10 +961,6 @@
 #endif
 
 
-// values for uninitialized variables
-#define DEDT_UNINITIALIZED (real)0.0
-
-
 
 
 // ############

--- a/include/Macro.h
+++ b/include/Macro.h
@@ -275,7 +275,7 @@
 
 # if ( EOS == EOS_NUCLEAR )
 #  define YE                  ( PASSIVE_NEXT_IDX2 )
-#  define DEDT_LB             ( YE - 1            )
+#  define DEDT_NU             ( YE - 1            )
 # if ( NUC_TABLE_MODE == NUC_TABLE_MODE_TEMP )
 #  define TEMP_IG             ( YE - 2            )
 #  define PASSIVE_NEXT_IDX3   ( YE - 3            )
@@ -324,7 +324,7 @@
 
 # if ( EOS == EOS_NUCLEAR )
 #  define FLUX_YE          ( FLUX_NEXT_IDX2  )
-#  define FLUX_DEDT_LB     ( FLUX_YE - 1     )
+#  define FLUX_DEDT_NU     ( FLUX_YE - 1     )
 # if ( NUC_TABLE_MODE == NUC_TABLE_MODE_TEMP )
 #  define FLUX_TEMP_IG     ( FLUX_YE - 2     )
 #  define FLUX_NEXT_IDX3   ( FLUX_YE - 3     )
@@ -359,7 +359,7 @@
 
 # if ( EOS == EOS_NUCLEAR )
 #  define _YE                 ( 1L << YE      )
-#  define _DEDT_LB            ( 1L << DEDT_LB )
+#  define _DEDT_NU            ( 1L << DEDT_NU )
 # if ( NUC_TABLE_MODE == NUC_TABLE_MODE_TEMP )
 #  define _TEMP_IG            ( 1L << TEMP_IG )
 # endif
@@ -396,7 +396,7 @@
 
 # if ( EOS == EOS_NUCLEAR )
 #  define _FLUX_YE            ( 1L << FLUX_YE      )
-#  define _FLUX_DEDT_LB       ( 1L << FLUX_DEDT_LB )
+#  define _FLUX_DEDT_NU       ( 1L << FLUX_DEDT_NU )
 # if ( NUC_TABLE_MODE == NUC_TABLE_MODE_TEMP )
 #  define _FLUX_TEMP_IG       ( 1L << FLUX_TEMP_IG )
 # endif

--- a/src/Fluid/Flu_FixUp_Restrict.cpp
+++ b/src/Fluid/Flu_FixUp_Restrict.cpp
@@ -299,11 +299,19 @@ void Flu_FixUp_Restrict( const int FaLv, const int SonFluSg, const int FaFluSg, 
 //    pressure, total energy density, and the dual-energy variable
 #     if ( MODEL == HYDRO )
 //    apply this correction only when preparing all fluid variables or magnetic field
+#     ifdef DEDT_NU
+#     ifdef MHD
+      if (  ( TVarCC & _TOTAL ) == ( _TOTAL - _DEDT_NU )  ||  ResMag  )
+#     else
+      if (  ( TVarCC & _TOTAL ) == ( _TOTAL - _DEDT_NU )  )
+#     endif
+#     else
 #     ifdef MHD
       if (  ( TVarCC & _TOTAL ) == _TOTAL  ||  ResMag  )
 #     else
       if (  ( TVarCC & _TOTAL ) == _TOTAL  )
 #     endif
+#     endif // #ifdef DEDT_NU ... else ...
       for (int k=0; k<PS1; k++)
       for (int j=0; j<PS1; j++)
       for (int i=0; i<PS1; i++)

--- a/src/Fluid/Flu_FixUp_Restrict.cpp
+++ b/src/Fluid/Flu_FixUp_Restrict.cpp
@@ -91,7 +91,11 @@ void Flu_FixUp_Restrict( const int FaLv, const int SonFluSg, const int FaFluSg, 
 #  else
    const bool ResMag  = false;
 #  endif
-   const int PS1_half = PS1 / 2;
+#  ifndef _DEDT_NU
+   const long _DEDT_NU = 0;
+#  endif
+   const long ResVar   = _TOTAL - _DEDT_NU;
+   const int  PS1_half = PS1 / 2;
 
 
 // determine the components to be restricted (TFluVarIdx : target fluid variable indices ( = [0 ... NCOMP_TOTAL-1] )
@@ -299,19 +303,11 @@ void Flu_FixUp_Restrict( const int FaLv, const int SonFluSg, const int FaFluSg, 
 //    pressure, total energy density, and the dual-energy variable
 #     if ( MODEL == HYDRO )
 //    apply this correction only when preparing all fluid variables or magnetic field
-#     ifdef DEDT_NU
 #     ifdef MHD
-      if (  ( TVarCC & _TOTAL ) == ( _TOTAL - _DEDT_NU )  ||  ResMag  )
+      if (  ( TVarCC & ResVar ) == ResVar  ||  ResMag  )
 #     else
-      if (  ( TVarCC & _TOTAL ) == ( _TOTAL - _DEDT_NU )  )
+      if (  ( TVarCC & ResVar ) == ResVar  )
 #     endif
-#     else
-#     ifdef MHD
-      if (  ( TVarCC & _TOTAL ) == _TOTAL  ||  ResMag  )
-#     else
-      if (  ( TVarCC & _TOTAL ) == _TOTAL  )
-#     endif
-#     endif // #ifdef DEDT_NU ... else ...
       for (int k=0; k<PS1; k++)
       for (int j=0; j<PS1; j++)
       for (int i=0; i<PS1; i++)

--- a/src/Fluid/Flu_FixUp_Restrict.cpp
+++ b/src/Fluid/Flu_FixUp_Restrict.cpp
@@ -94,7 +94,7 @@ void Flu_FixUp_Restrict( const int FaLv, const int SonFluSg, const int FaFluSg, 
 #  ifndef _DEDT_NU
    const long _DEDT_NU = 0;
 #  endif
-   const long ResVar   = _TOTAL - _DEDT_NU;
+   const long EoSVar   = _TOTAL - _DEDT_NU;
    const int  PS1_half = PS1 / 2;
 
 
@@ -303,11 +303,7 @@ void Flu_FixUp_Restrict( const int FaLv, const int SonFluSg, const int FaFluSg, 
 //    pressure, total energy density, and the dual-energy variable
 #     if ( MODEL == HYDRO )
 //    apply this correction only when preparing all fluid variables or magnetic field
-#     ifdef MHD
-      if (  ( TVarCC & ResVar ) == ResVar  ||  ResMag  )
-#     else
-      if (  ( TVarCC & ResVar ) == ResVar  )
-#     endif
+      if (  ( TVarCC & EoSVar ) == EoSVar  ||  ResMag  )
       for (int k=0; k<PS1; k++)
       for (int j=0; j<PS1; j++)
       for (int i=0; i<PS1; i++)

--- a/src/Init/Init_Field.cpp
+++ b/src/Init/Init_Field.cpp
@@ -116,8 +116,8 @@ void Init_Field()
    if ( Idx_Temp_IG != TEMP_IG )    Aux_Error( ERROR_INFO, "inconsistent Idx_Temp_IG (%d != %d) !!\n", Idx_Temp_IG, TEMP_IG );
 #  endif
 
-   Idx_dEdt_LB = AddField( "dEdt_LB", NORMALIZE_NO, INTERP_FRAC_NO  );
-   if ( Idx_dEdt_LB != DEDT_LB )    Aux_Error( ERROR_INFO, "inconsistent Idx_dEdt_LB (%d != %d) !!\n", Idx_dEdt_LB, DEDT_LB );
+   Idx_dEdt_Nu = AddField( "dEdt_Nu", NORMALIZE_NO, INTERP_FRAC_NO  );
+   if ( Idx_dEdt_Nu != DEDT_NU )    Aux_Error( ERROR_INFO, "inconsistent Idx_dEdt_Nu (%d != %d) !!\n", Idx_dEdt_Nu, DEDT_NU );
 
    Idx_Ye      = AddField( "Ye",      NORMALIZE_NO, INTERP_FRAC_YES );
    if ( Idx_Ye      != YE      )    Aux_Error( ERROR_INFO, "inconsistent Idx_Ye      (%d != %d) !!\n", Idx_Ye,      YE   );

--- a/src/Main/EvolveLevel.cpp
+++ b/src/Main/EvolveLevel.cpp
@@ -691,13 +691,19 @@ void EvolveLevel( const int lv, const double dTime_FaLv )
 //       12-1. use the average data on fine grids to correct the coarse-grid data
          if ( OPT__FIXUP_RESTRICT )
          {
+#           ifdef DEDT_NU
+            const long ResVar = _TOTAL - _DEDT_NU;
+#           else
+            const long ResVar = _TOTAL;
+#           endif
+
             TIMING_FUNC(   Flu_FixUp_Restrict( lv, amr->FluSg[lv+1], amr->FluSg[lv], amr->MagSg[lv+1], amr->MagSg[lv],
-                                               NULL_INT, NULL_INT, _TOTAL, _MAG ),
+                                               NULL_INT, NULL_INT, ResVar, _MAG ),
                            Timer_FixUp[lv],   TIMER_ON   );
 
 #           ifdef LOAD_BALANCE
             TIMING_FUNC(   LB_GetBufferData( lv, amr->FluSg[lv], amr->MagSg[lv], NULL_INT, DATA_RESTRICT,
-                                             _TOTAL, _MAG, NULL_INT ),
+                                             ResVar, _MAG, NULL_INT ),
                            Timer_GetBuf[lv][7],   TIMER_ON   );
 #           endif
          }

--- a/src/SourceTerms/LightBulb/CPU_Src_Lightbulb.cpp
+++ b/src/SourceTerms/LightBulb/CPU_Src_Lightbulb.cpp
@@ -209,8 +209,8 @@ static void Src_Lightbulb( real fluid[], const real B[],
    const real Eint_Update = Eint_Code + dEint_Code;
 
    fluid[ENGY] = Hydro_ConEint2Etot( fluid[DENS], fluid[MOMX], fluid[MOMY], fluid[MOMZ], Eint_Update, Emag );
-#  ifdef DEDT_LB
-   fluid[DEDT_LB] = FABS( rate_Code * Dens_Code );
+#  ifdef DEDT_NU
+   fluid[DEDT_NU] = FABS( rate_Code * Dens_Code );
 #  endif
 
 

--- a/src/SourceTerms/Src_AdvanceDt.cpp
+++ b/src/SourceTerms/Src_AdvanceDt.cpp
@@ -2,6 +2,13 @@
 
 
 
+// flag for checking whether the dEdt_Nu field is initialized
+#if ( EOS == EOS_NUCLEAR )
+bool IsInit_dEdt_Nu = false;
+#endif
+
+
+
 
 //-------------------------------------------------------------------------------------------------------
 // Function    :  Src_AdvanceDt
@@ -39,5 +46,8 @@ void Src_AdvanceDt( const int lv, const double TimeNew, const double TimeOld, co
 // major source-term function
    InvokeSolver( SRC_SOLVER, lv, TimeNew, TimeOld, dt, NULL_REAL, SaveSg_Flu, SaveSg_Mag, NULL_INT,
                  OverlapMPI, Overlap_Sync );
+
+
+   if ( SrcTerms.Lightbulb )   IsInit_dEdt_Nu = true;
 
 } // FUNCTION : Src_AdvanceDt

--- a/src/TestProblem/Hydro/CCSN/Init_TestProb_Hydro_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/Init_TestProb_Hydro_CCSN.cpp
@@ -441,7 +441,7 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
    real *Passive = new real [NCOMP_PASSIVE];
 
    Passive[ YE      - NCOMP_FLUID ] = Ye*Dens;
-   Passive[ DEDT_NU - NCOMP_FLUID ] = DEDT_UNINITIALIZED;
+   Passive[ DEDT_NU - NCOMP_FLUID ] = TINY_NUMBER;
 #  ifdef TEMP_IG
    Passive[ TEMP_IG - NCOMP_FLUID ] = Temp;
 #  endif

--- a/src/TestProblem/Hydro/CCSN/Init_TestProb_Hydro_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/Init_TestProb_Hydro_CCSN.cpp
@@ -441,7 +441,7 @@ void SetGridIC( real fluid[], const double x, const double y, const double z, co
    real *Passive = new real [NCOMP_PASSIVE];
 
    Passive[ YE      - NCOMP_FLUID ] = Ye*Dens;
-   Passive[ DEDT_LB - NCOMP_FLUID ] = DEDT_UNINITIALIZED;
+   Passive[ DEDT_NU - NCOMP_FLUID ] = DEDT_UNINITIALIZED;
 #  ifdef TEMP_IG
    Passive[ TEMP_IG - NCOMP_FLUID ] = Temp;
 #  endif

--- a/src/TestProblem/Hydro/CCSN/dtSolver_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/dtSolver_CCSN.cpp
@@ -81,7 +81,7 @@ double Mis_GetTimeStep_Lightbulb( const int lv, const double dTime_dt )
             const real  Emag = (real)0.5*(  SQR( B[MAGX] ) + SQR( B[MAGY] ) + SQR( B[MAGZ] )  );
 #           else
                   real *B    = NULL;
-            const real  Emag = NULL;
+            const real  Emag = NULL_REAL;
 #           endif // ifdef MHD ... else ...
 
             const real Eint_Code  = Hydro_Con2Eint( Dens, Momx, Momy, Momz, Engy, true, MIN_EINT, Emag );

--- a/src/TestProblem/Hydro/CCSN/dtSolver_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/dtSolver_CCSN.cpp
@@ -81,9 +81,9 @@ double Mis_GetTimeStep_Lightbulb( const int lv, const double dTime_dt )
             const real Eint_Code = Hydro_Con2Eint( Dens, Momx, Momy, Momz, Engy, true, MIN_EINT, Emag );
 
 
-#           ifdef DEDT_LB
-            real dEint_Code     = amr->patch[     amr->FluSg[lv] ][lv][PID]->fluid[DEDT_LB][k][j][i];
-            real dEint_Code_Old = amr->patch[ 1 - amr->FluSg[lv] ][lv][PID]->fluid[DEDT_LB][k][j][i];
+#           ifdef DEDT_NU
+            real dEint_Code     = amr->patch[     amr->FluSg[lv] ][lv][PID]->fluid[DEDT_NU][k][j][i];
+            real dEint_Code_Old = amr->patch[ 1 - amr->FluSg[lv] ][lv][PID]->fluid[DEDT_NU][k][j][i];
 #           else
             real dEint_Code     = DEDT_UNINITIALIZED;
             real dEint_Code_Old = DEDT_UNINITIALIZED;
@@ -92,7 +92,7 @@ double Mis_GetTimeStep_Lightbulb( const int lv, const double dTime_dt )
 
 //          call Src_Lightbulb() to compute the neutrino heating/cooling rate if not initialized yet
 //
-//          check DEDT_LB at both the Sg = 0 and 1
+//          check DEDT_NU at both the Sg = 0 and 1
 //          since the sandglass Sg = amr->FluSg[lv] may not equal to that used during initialization
             if ( dEint_Code     == DEDT_UNINITIALIZED ||
                  dEint_Code_Old == DEDT_UNINITIALIZED    )
@@ -117,8 +117,8 @@ double Mis_GetTimeStep_Lightbulb( const int lv, const double dTime_dt )
                                           MIN_DENS, MIN_PRES, MIN_EINT, NULL,
                                           Src_Lightbulb_AuxArray_Flt, Src_Lightbulb_AuxArray_Int );
 
-#              ifdef DEDT_LB
-               dEint_Code = fluid[DEDT_LB];
+#              ifdef DEDT_NU
+               dEint_Code = fluid[DEDT_NU];
 #              endif
             } // if ( dEint_Code == DEDT_UNINITIALIZED )
 

--- a/src/TestProblem/Hydro/CCSN/dtSolver_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/dtSolver_CCSN.cpp
@@ -74,12 +74,9 @@ double Mis_GetTimeStep_Lightbulb( const int lv, const double dTime_dt )
             const real Engy = amr->patch[ amr->FluSg[lv] ][lv][PID]->fluid[ENGY][k][j][i];
 
 #           ifdef MHD
-            const real *Bx_FC = amr->patch[ amr->MagSg[lv] ][lv][PID]->magnetic[MAGX];
-            const real *By_FC = amr->patch[ amr->MagSg[lv] ][lv][PID]->magnetic[MAGY];
-            const real *Bz_FC = amr->patch[ amr->MagSg[lv] ][lv][PID]->magnetic[MAGZ];
                   real B[NCOMP_MAG];
 
-            MHD_GetCellCenteredBField( B, Bx_FC, By_FC, Bz_FC, PS1, PS1, PS1, i, j, k );
+            MHD_GetCellCenteredBFieldInPatch( B, lv, PID, i, j, k, amr->MagSg[lv] );
 
             const real  Emag = (real)0.5*(  SQR( B[MAGX] ) + SQR( B[MAGY] ) + SQR( B[MAGZ] )  );
 #           else


### PR DESCRIPTION
- Rename `dEdt_LB` to `dEdt_NU` for neutrino heating/cooling, which will be also used in the leakage scheme later
- Use flag `IsInit_dEdt_Nu` instead for checking whether the field `dEdt_NU` is initialized.
- Initialize the field to be `TINY_NUMBER`, rather than 0.0, because a floor value `TINY_NUMBER` is applied to the passive fields
- Disable applying restriction to the `dEdt_NU` field
  - In the current template setup, the maximum heating rate is roughly near the center of cells on `lv = 0`. If we apply restriction and update the `dEdt_NU` from finer cells, the heating rate will be reduced that causes the evolution time-step is overestimated. Note the `flux_fixup` does not affect this field significant and thus not updated in this PR.