### PR TITLE
Change shock detection thresholds `CCSN_Shock_ThresFac_*` to runtime parameters

### DIFF
--- a/example/test_problem/Hydro/CCSN/Input__TestProb.CoreCollapse
+++ b/example/test_problem/Hydro/CCSN/Input__TestProb.CoreCollapse
@@ -37,4 +37,7 @@ CCSN_CC_Rot_R0            1.03376e8                # characteristic radius R_0 (
 CCSN_CC_Rot_Omega0        2.0                      # central angular frequency Omega_0 (in rad/s) in the analytical rotational profile  [0.5]
 CCSN_CC_Rot_Fac          -1.0                      # multiplication factor for the tabular rotational profile (<=0 -> off)              [-1.0]
 
-CCSN_Is_PostBounce        0                        # boolean that indicates whether core bounce has occurred  [0]
+CCSN_Is_PostBounce        0                        # boolean that indicates whether core bounce has occurred   [0]
+
+CCSN_Shock_ThresFac_Pres  0.5                      # pressure threshold factor for detecting postbounce shock  [0.5]
+CCSN_Shock_ThresFac_Vel   0.1                      # velocity threshold facotr for detecting postbounce shock  [0.1]

--- a/example/test_problem/Hydro/CCSN/Input__TestProb.Lightbulb
+++ b/example/test_problem/Hydro/CCSN/Input__TestProb.Lightbulb
@@ -20,7 +20,10 @@ CCSN_Eint_Mode   1                                 # Mode of obtaining internal 
                                                    # ( 1=Temp Mode: Eint(dens, temp, [Ye])
                                                    #   2=Pres Mode: Eint(dens, pres, [Ye]) )
 
-CCSN_MaxRefine_RadFac  0.15                        # factor that determines the maximum refinement level based on distance from the box center  [0.15]
-CCSN_LB_TimeFac        0.10                        # factor that scales the dt constrained by lightbulb scheme  [0.1]
+CCSN_MaxRefine_RadFac     0.15                     # factor that determines the maximum refinement level based on distance from the box center  [0.15]
+CCSN_LB_TimeFac           0.10                     # factor that scales the dt constrained by lightbulb scheme  [0.1]
 
-CCSN_Is_PostBounce     1                           # boolean that indicates whether core bounce has occurred   [0]
+CCSN_Is_PostBounce        0                        # boolean that indicates whether core bounce has occurred    [0]
+
+CCSN_Shock_ThresFac_Pres  0.5                      # pressure threshold factor for detecting postbounce shock   [0.5]
+CCSN_Shock_ThresFac_Vel   0.1                      # velocity threshold facotr for detecting postbounce shock   [0.1]

--- a/example/test_problem/Hydro/CCSN/Input__TestProb.PostBounce
+++ b/example/test_problem/Hydro/CCSN/Input__TestProb.PostBounce
@@ -20,4 +20,7 @@ CCSN_Eint_Mode   1                                 # Mode of obtaining internal 
                                                    # ( 1=Temp Mode: Eint(dens, temp, [Ye])
                                                    #   2=Pres Mode: Eint(dens, pres, [Ye]) )
 
-CCSN_Is_PostBounce     1                           # boolean that indicates whether core bounce has occurred  [0]
+CCSN_Is_PostBounce        1                           # boolean that indicates whether core bounce has occurred  [0]
+
+CCSN_Shock_ThresFac_Pres  0.5                      # pressure threshold factor for detecting postbounce shock    [0.5]
+CCSN_Shock_ThresFac_Vel   0.1                      # velocity threshold facotr for detecting postbounce shock    [0.1]

--- a/src/TestProblem/Hydro/CCSN/Init_TestProb_Hydro_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/Init_TestProb_Hydro_CCSN.cpp
@@ -64,6 +64,9 @@ static int        CCSN_Eint_Mode;                  // Mode of obtaining internal
        double     CCSN_CC_Rot_Fac;                 // multiplication factor for the tabular rotational profile
 
        bool       CCSN_Is_PostBounce = false;      // boolean that indicates whether core bounce has occurred
+
+       double     CCSN_Shock_ThresFac_Pres;        // pressure threshold factor for detecting postbounce shock
+       double     CCSN_Shock_ThresFac_Vel;         // velocity threshold facotr for detecting postbounce shock
 // =======================================================================================
 
 
@@ -173,6 +176,8 @@ void SetParameter()
    ReadPara->Add( "CCSN_CC_Rot_Omega0",       &CCSN_CC_Rot_Omega0,       0.5,           0.0,              NoMax_double      );
    ReadPara->Add( "CCSN_CC_Rot_Fac",          &CCSN_CC_Rot_Fac,          -1.0,          NoMin_double,     NoMax_double      );
    ReadPara->Add( "CCSN_Is_PostBounce",       &CCSN_Is_PostBounce,       false,         Useless_bool,     Useless_bool      );
+   ReadPara->Add( "CCSN_Shock_ThresFac_Pres", &CCSN_Shock_ThresFac_Pres, 0.5,           Eps_double,       NoMax_double      );
+   ReadPara->Add( "CCSN_Shock_ThresFac_Vel" , &CCSN_Shock_ThresFac_Vel,  0.1,           Eps_double,       NoMax_double      );
 
    ReadPara->Read( FileName );
 
@@ -306,7 +311,9 @@ void SetParameter()
       if ( CCSN_Prob != Migration_Test ) {
       Aux_Message( stdout, "  radial factor for maximum refine level              = %13.7e\n", CCSN_MaxRefine_RadFac    );
       Aux_Message( stdout, "  scaling factor for lightbulb dt                     = %13.7e\n", CCSN_LB_TimeFac          );
-      Aux_Message( stdout, "  has core bounce occurred                            = %d\n",     CCSN_Is_PostBounce       );   }
+      Aux_Message( stdout, "  has core bounce occurred                            = %d\n",     CCSN_Is_PostBounce       );
+      Aux_Message( stdout, "  pressure threshold factor for detecting shock       = %13.7e\n", CCSN_Shock_ThresFac_Pres );
+      Aux_Message( stdout, "  velocity threshold factor for detecting shock       = %13.7e\n", CCSN_Shock_ThresFac_Vel  );   }
       if ( CCSN_Prob == Core_Collapse ) {
       if ( CCSN_CC_MaxRefine_Flag1 ) {
       Aux_Message( stdout, "  reduced maxmimum refinement lv 1                    = %d\n",     CCSN_CC_MaxRefine_LV1    );

--- a/src/TestProblem/Hydro/CCSN/Record_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/Record_CCSN.cpp
@@ -6,6 +6,8 @@
        double CCSN_Rsh_Max = 0.0;
        double CCSN_Rsh_Ave = 0.0;
 extern bool   CCSN_Is_PostBounce;
+extern double CCSN_Shock_ThresFac_Pres;
+extern double CCSN_Shock_ThresFac_Vel;
 
 
 
@@ -485,8 +487,6 @@ void Detect_Shock()
    const int VELZ    = NCOMP_PASSIVE + 3;
    const int PRES    = NCOMP_PASSIVE + 4;
 
-   const real   ThresholdFac_Pres = 0.5;
-   const real   ThresholdFac_Vel  = 0.1;
    const double BoxCenter[3]      = { amr->BoxCenter[0], amr->BoxCenter[1], amr->BoxCenter[2] };
 
 
@@ -613,8 +613,8 @@ void Detect_Shock()
                                           +     ( Fluid[VELX][kk  ][jj  ][ii+1] - Fluid[VELX][kk  ][jj  ][ii-1] )  );
 
 //             (4) examine the criteria for detecting strong shock
-               if (  ( GradP >=  ThresholdFac_Pres * Pres_Min[kk][jj][ii] )  &&
-                     ( DivV  <= -ThresholdFac_Vel  * Cs_Min  [kk][jj][ii] )      )
+               if (  ( GradP >=  CCSN_Shock_ThresFac_Pres * Pres_Min[kk][jj][ii] )  &&
+                     ( DivV  <= -CCSN_Shock_ThresFac_Vel  * Cs_Min  [kk][jj][ii] )      )
                {
                   OMP_Shock_Min   [TID]  = fmin( r, OMP_Shock_Min[TID] );
                   OMP_Shock_Max   [TID]  = fmax( r, OMP_Shock_Max[TID] );


### PR DESCRIPTION
Make shock detection threshold `CCSN_Shock_ThresFac_Pres` & `CCSN_Shock_ThresFac_Pres` Runtime Parameters.

Here I renamed `ThresholdFac_*` and change it to runtime parameters.

I have set the default value of `0.5` and `0.1` respectively as it was hard coded.
For the minimum and maximum values are set to be `Eps_double`  and `NoMax_double`.