### PR TITLE
Fix an EoS bug with checking variables' range

### DIFF
--- a/src/EoS/Nuclear/NuclearEoS.cpp
+++ b/src/EoS/Nuclear/NuclearEoS.cpp
@@ -191,7 +191,7 @@ void nuc_eos_C_short( real *Out, const real *In,
 #        else
          if ( leps >  table_chk[npt_chk-1]  )  {  *keyerr = 110;  return;  }
          if ( leps <  table_chk[        0]  )  {  *keyerr = 111;  return;  }
-#        endif // if ( NUC_TABLE_MODE == NUC_TABLE_MODE_TEMP )
+#        endif // if ( NUC_TABLE_MODE == NUC_TABLE_MODE_TEMP ) ... else ...
 #        endif // if ( NUC_EOS_SOLVER != NUC_EOS_SOLVER_ORIG )
          if ( leps != leps                  )  {  *keyerr = 112;  return;  }
       }

--- a/src/EoS/Nuclear/NuclearEoS.cpp
+++ b/src/EoS/Nuclear/NuclearEoS.cpp
@@ -183,14 +183,12 @@ void nuc_eos_C_short( real *Out, const real *In,
                      ltoreps   = leps;
 #        endif
 
-#        if ( NUC_EOS_SOLVER != NUC_EOS_SOLVER_ORIG )
-#        if ( NUC_TABLE_MODE == NUC_TABLE_MODE_ENGY )
-         if ( leps >  table_chk[npt_chk-1]  )  {  *keyerr = 110;  return;  }
-         if ( leps <  table_chk[        0]  )  {  *keyerr = 111;  return;  }
-#        endif
-#        else
+#        if ( NUC_EOS_SOLVER != NUC_EOS_SOLVER_ENGY )
          if ( leps >  table_chk[npt_chk-1]  )  {   in_aux_table = false;   }
          if ( leps <  table_chk[        0]  )  {   in_aux_table = false;   }
+#        else
+         if ( leps >  table_chk[npt_chk-1]  )  {  *keyerr = 110;  return;  }
+         if ( leps <  table_chk[        0]  )  {  *keyerr = 111;  return;  }
 #        endif
          if ( leps != leps                  )  {  *keyerr = 112;  return;  }
       }

--- a/src/EoS/Nuclear/NuclearEoS.cpp
+++ b/src/EoS/Nuclear/NuclearEoS.cpp
@@ -141,9 +141,6 @@ void nuc_eos_C_short( real *Out, const real *In,
          real  var_mode = NULL_REAL;
          int   var_idx;
               *keyerr   = 0;
-#  if ( NUC_EOS_SOLVER != NUC_EOS_SOLVER_ORIG )
-         bool  in_aux_table = true;
-#  endif
 
 #  if ( NUC_TABLE_MODE == NUC_TABLE_MODE_TEMP )
    real lt_IG = 1.0;
@@ -184,8 +181,8 @@ void nuc_eos_C_short( real *Out, const real *In,
 #        endif
 
 #        if ( NUC_EOS_SOLVER != NUC_EOS_SOLVER_ENGY )
-         if ( leps >  table_chk[npt_chk-1]  )  {   in_aux_table = false;   }
-         if ( leps <  table_chk[        0]  )  {   in_aux_table = false;   }
+         if ( leps >  table_chk[npt_chk-1]  )  {  *keyerr = 110;           }
+         if ( leps <  table_chk[        0]  )  {  *keyerr = 111;           }
 #        else
          if ( leps >  table_chk[npt_chk-1]  )  {  *keyerr = 110;  return;  }
          if ( leps <  table_chk[        0]  )  {  *keyerr = 111;  return;  }
@@ -224,8 +221,8 @@ void nuc_eos_C_short( real *Out, const real *In,
                     var_idx  = NUC_VAR_IDX_ENTR;
 
 #        if ( NUC_EOS_SOLVER != NUC_EOS_SOLVER_ORIG )
-         if ( entr >  mode_Aux[nmode_Aux-1] )  {   in_aux_table = false;   }
-         if ( entr <  mode_Aux[          0] )  {   in_aux_table = false;   }
+         if ( entr >  mode_Aux[nmode_Aux-1] )  {  *keyerr = 130;           }
+         if ( entr <  mode_Aux[          0] )  {  *keyerr = 131;           }
 #        endif
          if ( entr != entr                  )  {  *keyerr = 132;  return;  }
       }
@@ -239,8 +236,8 @@ void nuc_eos_C_short( real *Out, const real *In,
                     var_idx  = NUC_VAR_IDX_PRES;
 
 #        if ( NUC_EOS_SOLVER != NUC_EOS_SOLVER_ORIG )
-         if ( lprs >  mode_Aux[nmode_Aux-1] )  {   in_aux_table = false;   }
-         if ( lprs <  mode_Aux[          0] )  {   in_aux_table = false;   }
+         if ( lprs >  mode_Aux[nmode_Aux-1] )  {  *keyerr = 140;           }
+         if ( lprs <  mode_Aux[          0] )  {  *keyerr = 141;           }
 #        endif
          if ( lprs != lprs                  )  {  *keyerr = 142;  return;  }
       }
@@ -255,23 +252,24 @@ void nuc_eos_C_short( real *Out, const real *In,
 #     if ( NUC_EOS_SOLVER != NUC_EOS_SOLVER_ORIG )
       const real *table_Aux = alltables_Aux + var_idx*nrho_Aux*nmode_Aux*nye_Aux;
 
-#     if   ( NUC_EOS_SOLVER == NUC_EOS_SOLVER_LUT    )
-      if ( in_aux_table )
+      if ( *keyerr == 0 )
+      {
+#        if   ( NUC_EOS_SOLVER == NUC_EOS_SOLVER_LUT    )
          findtoreps( lr, var_mode, xye, &ltoreps, table_Aux, nrho_Aux, nmode_Aux, nye_Aux, ntoreps,
                      logrho_Aux, mode_Aux, yes_Aux, logtoreps, IntScheme_Aux, keyerr );
 
-#     elif ( NUC_EOS_SOLVER == NUC_EOS_SOLVER_DIRECT )
-      if ( in_aux_table )
+#        elif ( NUC_EOS_SOLVER == NUC_EOS_SOLVER_DIRECT )
          findtoreps_direct( lr, var_mode, xye, &ltoreps, alltables, table_Aux, nrho, ntoreps, nye, nmode_Aux,
                             logrho, logtoreps, yes, mode_Aux, keymode, keyerr );
-#     endif
+#        endif
+      }
 #     endif // if ( NUC_EOS_SOLVER != NUC_EOS_SOLVER_ORIG )
 
 
 //    (b) Newton-Raphson and bisection methods (for temperature-based table only)
 #     if ( NUC_TABLE_MODE == NUC_TABLE_MODE_TEMP )
 #     if ( NUC_EOS_SOLVER != NUC_EOS_SOLVER_ORIG )
-      if ( *keyerr != 0  ||  !in_aux_table )
+      if ( *keyerr != 0 )
 #     endif
          findtemp_NR_bisection( lr, lt_IG, xye, var_mode, &ltoreps, nrho, ntoreps, nye, alltables,
                                 logrho, logtoreps, yes, keymode, keyerr, rfeps );

--- a/src/EoS/Nuclear/NuclearEoS.cpp
+++ b/src/EoS/Nuclear/NuclearEoS.cpp
@@ -184,12 +184,13 @@ void nuc_eos_C_short( real *Out, const real *In,
 #        endif
 
 #        if ( NUC_EOS_SOLVER != NUC_EOS_SOLVER_ORIG )
-         if ( leps >  table_chk[npt_chk-1]  )  {   in_aux_table = false;   }
-         if ( leps <  table_chk[        0]  )  {   in_aux_table = false;   }
-#        endif
 #        if ( NUC_TABLE_MODE == NUC_TABLE_MODE_ENGY )
          if ( leps >  table_chk[npt_chk-1]  )  {  *keyerr = 110;  return;  }
          if ( leps <  table_chk[        0]  )  {  *keyerr = 111;  return;  }
+#        endif
+#        else
+         if ( leps >  table_chk[npt_chk-1]  )  {   in_aux_table = false;   }
+         if ( leps <  table_chk[        0]  )  {   in_aux_table = false;   }
 #        endif
          if ( leps != leps                  )  {  *keyerr = 112;  return;  }
       }

--- a/src/EoS/Nuclear/NuclearEoS.cpp
+++ b/src/EoS/Nuclear/NuclearEoS.cpp
@@ -191,8 +191,8 @@ void nuc_eos_C_short( real *Out, const real *In,
 #        else
          if ( leps >  table_chk[npt_chk-1]  )  {  *keyerr = 110;  return;  }
          if ( leps <  table_chk[        0]  )  {  *keyerr = 111;  return;  }
-#        endif
-#        endif
+#        endif // if ( NUC_TABLE_MODE == NUC_TABLE_MODE_TEMP )
+#        endif // if ( NUC_EOS_SOLVER != NUC_EOS_SOLVER_ORIG )
          if ( leps != leps                  )  {  *keyerr = 112;  return;  }
       }
       break;

--- a/src/EoS/Nuclear/NuclearEoS.cpp
+++ b/src/EoS/Nuclear/NuclearEoS.cpp
@@ -184,15 +184,13 @@ void nuc_eos_C_short( real *Out, const real *In,
                      ltoreps   = leps;
 #        endif
 
-#        if ( NUC_EOS_SOLVER == NUC_EOS_SOLVER_ORIG )
-#        if ( NUC_TABLE_MODE != NUC_TABLE_MODE_TEMP )
+#        if   ( NUC_EOS_SOLVER == NUC_EOS_SOLVER_ORIG )
+#        if   ( NUC_TABLE_MODE != NUC_TABLE_MODE_TEMP )
          if ( leps >  table_chk[npt_chk-1]  )  {  *keyerr = 110;  return;  }
          if ( leps <  table_chk[        0]  )  {  *keyerr = 111;  return;  }
 #        endif
-#        endif
-
-#        if ( NUC_EOS_SOLVER != NUC_EOS_SOLVER_ORIG )
-#        if ( NUC_TABLE_MODE == NUC_TABLE_MODE_TEMP )
+#        elif ( NUC_EOS_SOLVER != NUC_EOS_SOLVER_ORIG )
+#        if   ( NUC_TABLE_MODE == NUC_TABLE_MODE_TEMP )
          if ( leps >  table_chk[npt_chk-1]  )  {  *keyerr = 110;           }
          if ( leps <  table_chk[        0]  )  {  *keyerr = 111;           }
 #        else

--- a/src/EoS/Nuclear/NuclearEoS.cpp
+++ b/src/EoS/Nuclear/NuclearEoS.cpp
@@ -184,20 +184,15 @@ void nuc_eos_C_short( real *Out, const real *In,
                      ltoreps   = leps;
 #        endif
 
-#        if   ( NUC_EOS_SOLVER == NUC_EOS_SOLVER_ORIG )
-#        if   ( NUC_TABLE_MODE != NUC_TABLE_MODE_TEMP )
-         if ( leps >  table_chk[npt_chk-1]  )  {  *keyerr = 110;  return;  }
-         if ( leps <  table_chk[        0]  )  {  *keyerr = 111;  return;  }
-#        endif
-#        elif ( NUC_EOS_SOLVER != NUC_EOS_SOLVER_ORIG )
-#        if   ( NUC_TABLE_MODE == NUC_TABLE_MODE_TEMP )
+#        if ( NUC_TABLE_MODE == NUC_TABLE_MODE_TEMP )
+#        if ( NUC_EOS_SOLVER != NUC_EOS_SOLVER_ORIG )
          if ( leps >  table_chk[npt_chk-1]  )  {  *keyerr = 110;           }
          if ( leps <  table_chk[        0]  )  {  *keyerr = 111;           }
+#        endif
 #        else
          if ( leps >  table_chk[npt_chk-1]  )  {  *keyerr = 110;  return;  }
          if ( leps <  table_chk[        0]  )  {  *keyerr = 111;  return;  }
 #        endif // if ( NUC_TABLE_MODE == NUC_TABLE_MODE_TEMP ) ... else ...
-#        endif
          if ( leps != leps                  )  {  *keyerr = 112;  return;  }
       }
       break;

--- a/src/EoS/Nuclear/NuclearEoS.cpp
+++ b/src/EoS/Nuclear/NuclearEoS.cpp
@@ -109,7 +109,11 @@ void findtemp_NR_bisection( const real lr, const real lt_IG, const real ye, cons
 //                                     120 : temp too high
 //                                     121 : temp too low
 //                                     122 : temp NaN
+//                                     130 : entr too high
+//                                     131 : entr too low
 //                                     132 : entr NaN
+//                                     140 : pres too high
+//                                     141 : pres too low
 //                                     142 : pres NaN
 //                                     150 : Ye   too high
 //                                     151 : Ye   too low
@@ -180,12 +184,14 @@ void nuc_eos_C_short( real *Out, const real *In,
                      ltoreps   = leps;
 #        endif
 
-#        if ( NUC_EOS_SOLVER != NUC_EOS_SOLVER_ENGY )
+#        if ( NUC_EOS_SOLVER != NUC_EOS_SOLVER_ORIG )
+#        if ( NUC_TABLE_MODE == NUC_TABLE_MODE_TEMP )
          if ( leps >  table_chk[npt_chk-1]  )  {  *keyerr = 110;           }
          if ( leps <  table_chk[        0]  )  {  *keyerr = 111;           }
 #        else
          if ( leps >  table_chk[npt_chk-1]  )  {  *keyerr = 110;  return;  }
          if ( leps <  table_chk[        0]  )  {  *keyerr = 111;  return;  }
+#        endif
 #        endif
          if ( leps != leps                  )  {  *keyerr = 112;  return;  }
       }

--- a/src/EoS/Nuclear/NuclearEoS.cpp
+++ b/src/EoS/Nuclear/NuclearEoS.cpp
@@ -184,6 +184,13 @@ void nuc_eos_C_short( real *Out, const real *In,
                      ltoreps   = leps;
 #        endif
 
+#        if ( NUC_EOS_SOLVER == NUC_EOS_SOLVER_ORIG )
+#        if ( NUC_TABLE_MODE != NUC_TABLE_MODE_TEMP )
+         if ( leps >  table_chk[npt_chk-1]  )  {  *keyerr = 110;  return;  }
+         if ( leps <  table_chk[        0]  )  {  *keyerr = 111;  return;  }
+#        endif
+#        endif
+
 #        if ( NUC_EOS_SOLVER != NUC_EOS_SOLVER_ORIG )
 #        if ( NUC_TABLE_MODE == NUC_TABLE_MODE_TEMP )
          if ( leps >  table_chk[npt_chk-1]  )  {  *keyerr = 110;           }
@@ -192,7 +199,7 @@ void nuc_eos_C_short( real *Out, const real *In,
          if ( leps >  table_chk[npt_chk-1]  )  {  *keyerr = 110;  return;  }
          if ( leps <  table_chk[        0]  )  {  *keyerr = 111;  return;  }
 #        endif // if ( NUC_TABLE_MODE == NUC_TABLE_MODE_TEMP ) ... else ...
-#        endif // if ( NUC_EOS_SOLVER != NUC_EOS_SOLVER_ORIG )
+#        endif
          if ( leps != leps                  )  {  *keyerr = 112;  return;  }
       }
       break;


### PR DESCRIPTION
Fixed a bug when checking the variables' range (internal energy, pressure, entropy)

- Fixed a bug for `NUC_EOS_SOLVER != NUC_EOS_SOLVER_ORIG`.
- Do not return errors when the variables are out of auxiliary tables.
- Switch to `NR/Bisection` when the variables are not in the tables. 
