### PR TITLE
Improve the GREP routine

### DIFF
--- a/example/test_problem/Hydro/CCSN/Input__Parameter.CoreCollapse
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.CoreCollapse
@@ -201,6 +201,8 @@ GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
                                           # (<=0=use amr->dh[MAX_LEVEL])
 GREP_OPT_FIXUP                1           # fix up the profiles after grid allocation/deallocation       [1]
+GREP_OPT_PRES                 1           # pressure computation scheme                                  [1]
+                                          # (0=individual cell, 1=binned data)
 
 
 # initialization

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.CoreCollapse
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.CoreCollapse
@@ -190,7 +190,7 @@ SRC_GPU_NPGROUP              -1           # number of patch groups sent into the
 
 
 # GREP
-GREP_CENTER_METHOD            0           # center of the GREP profile                                   [0]
+GREP_CENTER_METHOD            2           # center of the GREP profile                                   [2]
                                           # (0=box center, 1=density maximum, 2=potential minimum, 3=CoM)
 GREP_MAXITER                  1000        # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
 GREP_LOGBIN                   1           # log/linear bins                                              [true]

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.CoreCollapse
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.CoreCollapse
@@ -190,8 +190,8 @@ SRC_GPU_NPGROUP              -1           # number of patch groups sent into the
 
 
 # GREP
-GREP_CENTER_METHOD            2           # center of the GREP profile                                   [2]
-                                          # (0=box center, 1=density maximum, 2=potential minimum, 3=CoM)
+GREP_CENTER_METHOD            3           # center of the GREP profile                                   [3]
+                                          # (1=box center, 2=density maximum, 3=potential minimum, 4=CoM)
 GREP_MAXITER                  1000        # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
 GREP_LOGBIN                   1           # log/linear bins                                              [true]
                                           # (true=logarithmic, false=linear)
@@ -201,8 +201,8 @@ GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
                                           # (<=0=amr->dh[MAX_LEVEL])
 GREP_OPT_FIXUP                1           # correct the profiles after grid allocation/deallocation      [1]
-GREP_OPT_PRES                 1           # pressure computation scheme                                  [1]
-                                          # (0=individual cell, 1=binned data)
+GREP_OPT_PRES                 2           # pressure computation scheme                                  [2]
+                                          # (1=individual cell, 2=binned data)
 
 
 # initialization

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.CoreCollapse
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.CoreCollapse
@@ -190,7 +190,7 @@ SRC_GPU_NPGROUP              -1           # number of patch groups sent into the
 
 
 # GREP
-GREP_CENTER_METHOD            0           # center of radial profile                                     [0]
+GREP_CENTER_METHOD            0           # center of the GREP profile                                   [0]
                                           # (0=box center, 1=density maximum, 2=potential minimum, 3=CoM)
 GREP_MAXITER                  1000        # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
 GREP_LOGBIN                   1           # log/linear bins                                              [true]
@@ -199,8 +199,8 @@ GREP_LOGBINRATIO              1.0025      # ratio of adjacent log bins          
 GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile                         [-1.0]
                                           # (<=0=sqrt(3.0)*BOX_SIZE)
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
-                                          # (<=0=use amr->dh[MAX_LEVEL])
-GREP_OPT_FIXUP                1           # fix up the profiles after grid allocation/deallocation       [1]
+                                          # (<=0=amr->dh[MAX_LEVEL])
+GREP_OPT_FIXUP                1           # correct the profiles after grid allocation/deallocation      [1]
 GREP_OPT_PRES                 1           # pressure computation scheme                                  [1]
                                           # (0=individual cell, 1=binned data)
 

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.CoreCollapse
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.CoreCollapse
@@ -190,14 +190,14 @@ SRC_GPU_NPGROUP              -1           # number of patch groups sent into the
 
 
 # GREP
-GREP_CENTER_METHOD            1           # center of radial profile                                     [1]
-                                          # (1=box center)
+GREP_CENTER_METHOD            0           # center of radial profile                                     [0]
+                                          # (0=box center, 1=density maximum, 2=potential minimum, 3=CoM)
 GREP_MAXITER                  1000        # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
 GREP_LOGBIN                   1           # log/linear bins                                              [true]
                                           # (true=logarithmic, false=linear)
 GREP_LOGBINRATIO              1.0025      # ratio of adjacent log bins                                   [1.25]
 GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile                         [-1.0]
-                                          # (<=0=distance of the farthest vertex to the center)
+                                          # (<=0=sqrt(3.0)*BOX_SIZE)
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
                                           # (<=0=use amr->dh[MAX_LEVEL])
 GREP_OPT_FIXUP                1           # fix up the profiles after grid allocation/deallocation       [1]

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.Lightbulb
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.Lightbulb
@@ -182,8 +182,8 @@ SRC_GPU_NPGROUP              -1           # number of patch groups sent into the
 
 
 # GREP
-GREP_CENTER_METHOD            2           # center of the GREP profile                                   [2]
-                                          # (0=box center, 1=density maximum, 2=potential minimum, 3=CoM)
+GREP_CENTER_METHOD            3           # center of the GREP profile                                   [3]
+                                          # (1=box center, 2=density maximum, 3=potential minimum, 4=CoM)
 GREP_MAXITER                  1000        # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
 GREP_LOGBIN                   1           # log/linear bins                                              [true]
                                           # (true=logarithmic, false=linear)
@@ -193,8 +193,8 @@ GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
                                           # (<=0=amr->dh[MAX_LEVEL])
 GREP_OPT_FIXUP                1           # correct the profiles after grid allocation/deallocation      [1]
-GREP_OPT_PRES                 1           # pressure computation scheme                                  [1]
-                                          # (0=individual cell, 1=binned data)
+GREP_OPT_PRES                 2           # pressure computation scheme                                  [2]
+                                          # (1=individual cell, 2=binned data)
 
 
 # initialization

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.Lightbulb
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.Lightbulb
@@ -182,14 +182,14 @@ SRC_GPU_NPGROUP              -1           # number of patch groups sent into the
 
 
 # GREP
-GREP_CENTER_METHOD            1           # center of radial profile                                     [1]
-                                          # (1=box center)
+GREP_CENTER_METHOD            0           # center of radial profile                                     [0]
+                                          # (0=box center, 1=density maximum, 2=potential minimum, 3=CoM)
 GREP_MAXITER                  1000        # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
 GREP_LOGBIN                   1           # log/linear bins                                              [true]
                                           # (true=logarithmic, false=linear)
 GREP_LOGBINRATIO              1.0025      # ratio of adjacent log bins                                   [1.25]
 GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile                         [-1.0]
-                                          # (<=0=distance of the farthest vertex to the center)
+                                          # (<=0=sqrt(3.0)*BOX_SIZE)
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
                                           # (<=0=use amr->dh[MAX_LEVEL])
 GREP_OPT_FIXUP                1           # fix up the profiles after grid allocation/deallocation       [1]

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.Lightbulb
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.Lightbulb
@@ -193,6 +193,8 @@ GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
                                           # (<=0=use amr->dh[MAX_LEVEL])
 GREP_OPT_FIXUP                1           # fix up the profiles after grid allocation/deallocation       [1]
+GREP_OPT_PRES                 1           # pressure computation scheme                                  [1]
+                                          # (0=individual cell, 1=binned data)
 
 
 # initialization

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.Lightbulb
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.Lightbulb
@@ -182,7 +182,7 @@ SRC_GPU_NPGROUP              -1           # number of patch groups sent into the
 
 
 # GREP
-GREP_CENTER_METHOD            0           # center of radial profile                                     [0]
+GREP_CENTER_METHOD            0           # center of the GREP profile                                   [0]
                                           # (0=box center, 1=density maximum, 2=potential minimum, 3=CoM)
 GREP_MAXITER                  1000        # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
 GREP_LOGBIN                   1           # log/linear bins                                              [true]
@@ -191,8 +191,8 @@ GREP_LOGBINRATIO              1.0025      # ratio of adjacent log bins          
 GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile                         [-1.0]
                                           # (<=0=sqrt(3.0)*BOX_SIZE)
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
-                                          # (<=0=use amr->dh[MAX_LEVEL])
-GREP_OPT_FIXUP                1           # fix up the profiles after grid allocation/deallocation       [1]
+                                          # (<=0=amr->dh[MAX_LEVEL])
+GREP_OPT_FIXUP                1           # correct the profiles after grid allocation/deallocation      [1]
 GREP_OPT_PRES                 1           # pressure computation scheme                                  [1]
                                           # (0=individual cell, 1=binned data)
 

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.Lightbulb
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.Lightbulb
@@ -182,7 +182,7 @@ SRC_GPU_NPGROUP              -1           # number of patch groups sent into the
 
 
 # GREP
-GREP_CENTER_METHOD            0           # center of the GREP profile                                   [0]
+GREP_CENTER_METHOD            2           # center of the GREP profile                                   [2]
                                           # (0=box center, 1=density maximum, 2=potential minimum, 3=CoM)
 GREP_MAXITER                  1000        # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
 GREP_LOGBIN                   1           # log/linear bins                                              [true]

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.MigrationTest
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.MigrationTest
@@ -174,8 +174,8 @@ OPT__EXT_POT                  3           # add external potential    (0=off, 1=
 
 
 # GREP
-GREP_CENTER_METHOD            2           # center of the GREP profile                                   [2]
-                                          # (0=box center, 1=density maximum, 2=potential minimum, 3=CoM)
+GREP_CENTER_METHOD            3           # center of the GREP profile                                   [3]
+                                          # (1=box center, 2=density maximum, 3=potential minimum, 4=CoM)
 GREP_MAXITER                  1000        # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
 GREP_LOGBIN                   1           # log/linear bins                                              [true]
                                           # (true=logarithmic, false=linear)
@@ -185,8 +185,8 @@ GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
                                           # (<=0=amr->dh[MAX_LEVEL])
 GREP_OPT_FIXUP                1           # correct the profiles after grid allocation/deallocation      [1]
-GREP_OPT_PRES                 1           # pressure computation scheme                                  [1]
-                                          # (0=individual cell, 1=binned data)
+GREP_OPT_PRES                 2           # pressure computation scheme                                  [2]
+                                          # (1=individual cell, 2=binned data)
 
 
 # initialization

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.MigrationTest
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.MigrationTest
@@ -174,14 +174,14 @@ OPT__EXT_POT                  3           # add external potential    (0=off, 1=
 
 
 # GREP
-GREP_CENTER_METHOD            1           # center of radial profile                                     [1]
-                                          # (1=box center)
+GREP_CENTER_METHOD            0           # center of radial profile                                     [0]
+                                          # (0=box center, 1=density maximum, 2=potential minimum, 3=CoM)
 GREP_MAXITER                  1000        # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
 GREP_LOGBIN                   1           # log/linear bins                                              [true]
                                           # (true=logarithmic, false=linear)
 GREP_LOGBINRATIO              1.0025      # ratio of adjacent log bins                                   [1.25]
 GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile                         [-1.0]
-                                          # (<=0=distance of the farthest vertex to the center)
+                                          # (<=0=sqrt(3.0)*BOX_SIZE)
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
                                           # (<=0=use amr->dh[MAX_LEVEL])
 GREP_OPT_FIXUP                1           # fix up the profiles after grid allocation/deallocation       [1]

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.MigrationTest
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.MigrationTest
@@ -185,6 +185,8 @@ GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
                                           # (<=0=use amr->dh[MAX_LEVEL])
 GREP_OPT_FIXUP                1           # fix up the profiles after grid allocation/deallocation       [1]
+GREP_OPT_PRES                 1           # pressure computation scheme                                  [1]
+                                          # (0=individual cell, 1=binned data)
 
 
 # initialization

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.MigrationTest
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.MigrationTest
@@ -174,7 +174,7 @@ OPT__EXT_POT                  3           # add external potential    (0=off, 1=
 
 
 # GREP
-GREP_CENTER_METHOD            0           # center of the GREP profile                                   [0]
+GREP_CENTER_METHOD            2           # center of the GREP profile                                   [2]
                                           # (0=box center, 1=density maximum, 2=potential minimum, 3=CoM)
 GREP_MAXITER                  1000        # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
 GREP_LOGBIN                   1           # log/linear bins                                              [true]

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.MigrationTest
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.MigrationTest
@@ -174,7 +174,7 @@ OPT__EXT_POT                  3           # add external potential    (0=off, 1=
 
 
 # GREP
-GREP_CENTER_METHOD            0           # center of radial profile                                     [0]
+GREP_CENTER_METHOD            0           # center of the GREP profile                                   [0]
                                           # (0=box center, 1=density maximum, 2=potential minimum, 3=CoM)
 GREP_MAXITER                  1000        # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
 GREP_LOGBIN                   1           # log/linear bins                                              [true]
@@ -183,8 +183,8 @@ GREP_LOGBINRATIO              1.0025      # ratio of adjacent log bins          
 GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile                         [-1.0]
                                           # (<=0=sqrt(3.0)*BOX_SIZE)
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
-                                          # (<=0=use amr->dh[MAX_LEVEL])
-GREP_OPT_FIXUP                1           # fix up the profiles after grid allocation/deallocation       [1]
+                                          # (<=0=amr->dh[MAX_LEVEL])
+GREP_OPT_FIXUP                1           # correct the profiles after grid allocation/deallocation      [1]
 GREP_OPT_PRES                 1           # pressure computation scheme                                  [1]
                                           # (0=individual cell, 1=binned data)
 

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.PostBounce
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.PostBounce
@@ -173,14 +173,14 @@ OPT__EXT_POT                  3           # add external potential    (0=off, 1=
 
 
 # GREP
-GREP_CENTER_METHOD            1           # center of radial profile                                     [1]
-                                          # (1=box center)
+GREP_CENTER_METHOD            0           # center of radial profile                                     [0]
+                                          # (0=box center, 1=density maximum, 2=potential minimum, 3=CoM)
 GREP_MAXITER                  1000        # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
 GREP_LOGBIN                   1           # log/linear bins                                              [true]
                                           # (true=logarithmic, false=linear)
 GREP_LOGBINRATIO              1.0025      # ratio of adjacent log bins                                   [1.25]
 GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile                         [-1.0]
-                                          # (<=0=distance of the farthest vertex to the center)
+                                          # (<=0=sqrt(3.0)*BOX_SIZE)
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
                                           # (<=0=use amr->dh[MAX_LEVEL])
 GREP_OPT_FIXUP                1           # fix up the profiles after grid allocation/deallocation       [1]

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.PostBounce
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.PostBounce
@@ -173,7 +173,7 @@ OPT__EXT_POT                  3           # add external potential    (0=off, 1=
 
 
 # GREP
-GREP_CENTER_METHOD            0           # center of radial profile                                     [0]
+GREP_CENTER_METHOD            0           # center of the GREP profile                                   [0]
                                           # (0=box center, 1=density maximum, 2=potential minimum, 3=CoM)
 GREP_MAXITER                  1000        # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
 GREP_LOGBIN                   1           # log/linear bins                                              [true]
@@ -182,8 +182,8 @@ GREP_LOGBINRATIO              1.0025      # ratio of adjacent log bins          
 GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile                         [-1.0]
                                           # (<=0=sqrt(3.0)*BOX_SIZE)
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
-                                          # (<=0=use amr->dh[MAX_LEVEL])
-GREP_OPT_FIXUP                1           # fix up the profiles after grid allocation/deallocation       [1]
+                                          # (<=0=amr->dh[MAX_LEVEL])
+GREP_OPT_FIXUP                1           # correct the profiles after grid allocation/deallocation      [1]
 GREP_OPT_PRES                 1           # pressure computation scheme                                  [1]
                                           # (0=individual cell, 1=binned data)
 

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.PostBounce
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.PostBounce
@@ -173,7 +173,7 @@ OPT__EXT_POT                  3           # add external potential    (0=off, 1=
 
 
 # GREP
-GREP_CENTER_METHOD            0           # center of the GREP profile                                   [0]
+GREP_CENTER_METHOD            2           # center of the GREP profile                                   [2]
                                           # (0=box center, 1=density maximum, 2=potential minimum, 3=CoM)
 GREP_MAXITER                  1000        # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
 GREP_LOGBIN                   1           # log/linear bins                                              [true]

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.PostBounce
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.PostBounce
@@ -184,6 +184,8 @@ GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
                                           # (<=0=use amr->dh[MAX_LEVEL])
 GREP_OPT_FIXUP                1           # fix up the profiles after grid allocation/deallocation       [1]
+GREP_OPT_PRES                 1           # pressure computation scheme                                  [1]
+                                          # (0=individual cell, 1=binned data)
 
 
 # initialization

--- a/example/test_problem/Hydro/CCSN/Input__Parameter.PostBounce
+++ b/example/test_problem/Hydro/CCSN/Input__Parameter.PostBounce
@@ -173,8 +173,8 @@ OPT__EXT_POT                  3           # add external potential    (0=off, 1=
 
 
 # GREP
-GREP_CENTER_METHOD            2           # center of the GREP profile                                   [2]
-                                          # (0=box center, 1=density maximum, 2=potential minimum, 3=CoM)
+GREP_CENTER_METHOD            3           # center of the GREP profile                                   [3]
+                                          # (1=box center, 2=density maximum, 3=potential minimum, 4=CoM)
 GREP_MAXITER                  1000        # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
 GREP_LOGBIN                   1           # log/linear bins                                              [true]
                                           # (true=logarithmic, false=linear)
@@ -184,8 +184,8 @@ GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
                                           # (<=0=amr->dh[MAX_LEVEL])
 GREP_OPT_FIXUP                1           # correct the profiles after grid allocation/deallocation      [1]
-GREP_OPT_PRES                 1           # pressure computation scheme                                  [1]
-                                          # (0=individual cell, 1=binned data)
+GREP_OPT_PRES                 2           # pressure computation scheme                                  [2]
+                                          # (1=individual cell, 2=binned data)
 
 
 # initialization

--- a/example/test_problem/Hydro/CCSN/clean.sh
+++ b/example/test_problem/Hydro/CCSN/clean.sh
@@ -3,4 +3,4 @@ rm -f Record__Note Record__Timing Record__TimeStep Record__PatchCount Record__Du
       Diag* BaseXYslice* BaseYZslice* BaseXZslice* BaseXline* BaseYline* BaseZline* BaseDiag* \
       PowerSpec_* Particle_* nohup.out Record__Performance Record__TimingMPI_* \
       Record__ParticleCount Record__User Patch_* Record__NCorrUnphy FailedPatchGroup* *.pyc Record__LoadBalance \
-      GRACKLE_INFO Record__DivB Record__CentralQuant Record__QuadMom_2nd
+      GRACKLE_INFO Record__DivB Record__CentralQuant Record__QuadMom_2nd GREP_Lv*

--- a/example/test_problem/Template/Input__Parameter
+++ b/example/test_problem/Template/Input__Parameter
@@ -297,8 +297,8 @@ EXT_POT_TABLE_FLOAT8         -1           # ...                     : double pre
                                           # --> not supported yet; use -1 for now
 
 # GREP
-GREP_CENTER_METHOD            2           # center of the GREP profile                                   [2]
-                                          # (0=box center, 1=density maximum, 2=potential minimum, 3=CoM)
+GREP_CENTER_METHOD            3           # center of the GREP profile                                   [3]
+                                          # (1=box center, 2=density maximum, 3=potential minimum, 4=CoM)
 GREP_MAXITER                  1000        # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
 GREP_LOGBIN                   1           # log/linear bins                                              [true]
                                           # (true=logarithmic, false=linear)
@@ -308,8 +308,8 @@ GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
                                           # (<=0=amr->dh[MAX_LEVEL])
 GREP_OPT_FIXUP                1           # correct the profiles after grid allocation/deallocation      [1]
-GREP_OPT_PRES                 1           # pressure computation scheme                                  [1]
-                                          # (0=individual cell, 1=binned data)
+GREP_OPT_PRES                 2           # pressure computation scheme                                  [2]
+                                          # (1=individual cell, 2=binned data)
 
 
 # initialization

--- a/example/test_problem/Template/Input__Parameter
+++ b/example/test_problem/Template/Input__Parameter
@@ -308,6 +308,8 @@ GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
                                           # (<=0=use amr->dh[MAX_LEVEL])
 GREP_OPT_FIXUP                1           # fix up the profiles after grid allocation/deallocation       [1]
+GREP_OPT_PRES                 1           # pressure computation scheme                                  [1]
+                                          # (0=individual cell, 1=binned data)
 
 
 # initialization

--- a/example/test_problem/Template/Input__Parameter
+++ b/example/test_problem/Template/Input__Parameter
@@ -297,14 +297,14 @@ EXT_POT_TABLE_FLOAT8         -1           # ...                     : double pre
                                           # --> not supported yet; use -1 for now
 
 # GREP
-GREP_CENTER_METHOD            1           # center of radial profile                                     [1]
-                                          # (1=box center)
+GREP_CENTER_METHOD            0           # center of radial profile                                     [0]
+                                          # (0=box center, 1=density maximum, 2=potential minimum, 3=CoM)
 GREP_MAXITER                  1000        # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
 GREP_LOGBIN                   1           # log/linear bins                                              [true]
                                           # (true=logarithmic, false=linear)
 GREP_LOGBINRATIO              1.0025      # ratio of adjacent log bins                                   [1.25]
 GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile                         [-1.0]
-                                          # (<=0=distance of the farthest vertex to the center)
+                                          # (<=0=sqrt(3.0)*BOX_SIZE)
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
                                           # (<=0=use amr->dh[MAX_LEVEL])
 GREP_OPT_FIXUP                1           # fix up the profiles after grid allocation/deallocation       [1]

--- a/example/test_problem/Template/Input__Parameter
+++ b/example/test_problem/Template/Input__Parameter
@@ -297,7 +297,7 @@ EXT_POT_TABLE_FLOAT8         -1           # ...                     : double pre
                                           # --> not supported yet; use -1 for now
 
 # GREP
-GREP_CENTER_METHOD            0           # center of the GREP profile                                   [0]
+GREP_CENTER_METHOD            2           # center of the GREP profile                                   [2]
                                           # (0=box center, 1=density maximum, 2=potential minimum, 3=CoM)
 GREP_MAXITER                  1000        # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
 GREP_LOGBIN                   1           # log/linear bins                                              [true]

--- a/example/test_problem/Template/Input__Parameter
+++ b/example/test_problem/Template/Input__Parameter
@@ -297,7 +297,7 @@ EXT_POT_TABLE_FLOAT8         -1           # ...                     : double pre
                                           # --> not supported yet; use -1 for now
 
 # GREP
-GREP_CENTER_METHOD            0           # center of radial profile                                     [0]
+GREP_CENTER_METHOD            0           # center of the GREP profile                                   [0]
                                           # (0=box center, 1=density maximum, 2=potential minimum, 3=CoM)
 GREP_MAXITER                  1000        # number of iterations for constructing mass_TOV and Gamma_TOV [1000]
 GREP_LOGBIN                   1           # log/linear bins                                              [true]
@@ -306,8 +306,8 @@ GREP_LOGBINRATIO              1.0025      # ratio of adjacent log bins          
 GREP_MAXRADIUS               -1.0         # maximum radius in the radial profile                         [-1.0]
                                           # (<=0=sqrt(3.0)*BOX_SIZE)
 GREP_MINBINSIZE              -1.0         # minimum bin size                                             [-1.0]
-                                          # (<=0=use amr->dh[MAX_LEVEL])
-GREP_OPT_FIXUP                1           # fix up the profiles after grid allocation/deallocation       [1]
+                                          # (<=0=amr->dh[MAX_LEVEL])
+GREP_OPT_FIXUP                1           # correct the profiles after grid allocation/deallocation      [1]
 GREP_OPT_PRES                 1           # pressure computation scheme                                  [1]
                                           # (0=individual cell, 1=binned data)
 

--- a/include/Global.h
+++ b/include/Global.h
@@ -286,6 +286,7 @@ extern double GREP_LOGBINRATIO;
 extern double GREP_MAXRADIUS;
 extern double GREP_MINBINSIZE;
 extern bool   GREP_OPT_FIXUP;
+extern int    GREP_OPT_PRES;
 
 
 // (2-11) source terms

--- a/include/Global.h
+++ b/include/Global.h
@@ -165,6 +165,15 @@ extern ExtPot_t CPUExtPot_Ptr;
 extern ExtAcc_t GPUExtAcc_Ptr;
 extern ExtPot_t GPUExtPot_Ptr;
 #endif
+
+extern GREP_Center_t     GREP_CENTER_METHOD;
+extern int               GREP_MAXITER;
+extern bool              GREP_LOGBIN;
+extern double            GREP_LOGBINRATIO;
+extern double            GREP_MAXRADIUS;
+extern double            GREP_MINBINSIZE;
+extern bool              GREP_OPT_FIXUP;
+extern GREP_PresScheme_t GREP_OPT_PRES;
 #endif // #ifdef GRAVITY
 
 
@@ -275,18 +284,6 @@ extern Nuc_IntScheme_t NUC_INT_SCHEME_AUX;
 extern Nuc_IntScheme_t NUC_INT_SCHEME_MAIN;
 #endif
 #endif // HYDRO
-
-
-// (2-10) GREP
-// =======================================================================================================
-extern int    GREP_CENTER_METHOD;
-extern int    GREP_MAXITER;
-extern bool   GREP_LOGBIN;
-extern double GREP_LOGBINRATIO;
-extern double GREP_MAXRADIUS;
-extern double GREP_MINBINSIZE;
-extern bool   GREP_OPT_FIXUP;
-extern int    GREP_OPT_PRES;
 
 
 // (2-11) source terms

--- a/include/HDF5_Typedef.h
+++ b/include/HDF5_Typedef.h
@@ -584,6 +584,7 @@ struct InputPara_t
    double GREP_MaxRadius;
    double GREP_MinBinSize;
    int    GREP_Opt_FixUp;
+   int    GREP_Opt_Pres;
 #  endif // #ifdef GRAVITY
 
 // source terms

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -400,7 +400,7 @@ void Poi_Prepare_Rho( const int lv, const double PrepTime, real h_Rho_Array_P[][
 void Poi_StorePotWithGhostZone( const int lv, const int PotSg, const bool AllPatch );
 #endif
 void CPU_ComputeGREP( const int lv, const double Time, const Profile_t *DensAve, const Profile_t *EngyAve,
-                      const Profile_t *VrAve, const Profile_t *PresAve, Profile_t *Phi_eff );
+                      const Profile_t *VrAve, const Profile_t *PresAve, Profile_t *EffPot );
 #endif // #ifdef GRAVITY
 
 

--- a/include/Prototype.h
+++ b/include/Prototype.h
@@ -399,8 +399,8 @@ void Poi_Prepare_Rho( const int lv, const double PrepTime, real h_Rho_Array_P[][
 #ifdef STORE_POT_GHOST
 void Poi_StorePotWithGhostZone( const int lv, const int PotSg, const bool AllPatch );
 #endif
-void CPU_ComputeGREP( const Profile_t *DensAve, const Profile_t *EngyAve, const Profile_t *VrAve,
-                      const Profile_t *PresAve, Profile_t *Phi_eff );
+void CPU_ComputeGREP( const int lv, const double Time, const Profile_t *DensAve, const Profile_t *EngyAve,
+                      const Profile_t *VrAve, const Profile_t *PresAve, Profile_t *Phi_eff );
 #endif // #ifdef GRAVITY
 
 

--- a/include/Typedef.h
+++ b/include/Typedef.h
@@ -374,15 +374,15 @@ const OptExtPot_t
 // effective GR potential
 typedef int GREP_PresScheme_t;
 const GREP_PresScheme_t
-   GREP_PRES_INDIVCELL = 0,
-   GREP_PRES_BINDATA   = 1;
+   GREP_PRES_INDIVCELL = 1,
+   GREP_PRES_BINDATA   = 2;
 
 typedef int GREP_Center_t;
 const GREP_Center_t
-   GREP_CENTER_BOX  = 0,
-   GREP_CENTER_DENS = 1,
-   GREP_CENTER_POT  = 2,
-   GREP_CENTER_COM  = 3;
+   GREP_CENTER_BOX  = 1,
+   GREP_CENTER_DENS = 2,
+   GREP_CENTER_POT  = 3,
+   GREP_CENTER_COM  = 4;
 
 
 // different usages of external potential when computing total potential on level Lv

--- a/include/Typedef.h
+++ b/include/Typedef.h
@@ -371,6 +371,13 @@ const OptExtPot_t
    EXT_POT_GREP  = 3;
 
 
+// effective GR potential
+typedef int GREP_PresScheme_t;
+const GREP_PresScheme_t
+   GREP_PRES_INDIVCELL = 0,
+   GREP_PRES_BINDATA   = 1;
+
+
 // different usages of external potential when computing total potential on level Lv
 // --> ADD     : add external potential on Lv
 //     SUB     : subtract external potential for preparing self-gravity potential on Lv-1

--- a/include/Typedef.h
+++ b/include/Typedef.h
@@ -377,6 +377,13 @@ const GREP_PresScheme_t
    GREP_PRES_INDIVCELL = 0,
    GREP_PRES_BINDATA   = 1;
 
+typedef int GREPCenter_t;
+const GREPCenter_t
+   GREP_CENTER_BOX  = 0,
+   GREP_CENTER_DENS = 1,
+   GREP_CENTER_POT  = 2,
+   GREP_CENTER_COM  = 3;
+
 
 // different usages of external potential when computing total potential on level Lv
 // --> ADD     : add external potential on Lv

--- a/include/Typedef.h
+++ b/include/Typedef.h
@@ -377,8 +377,8 @@ const GREP_PresScheme_t
    GREP_PRES_INDIVCELL = 0,
    GREP_PRES_BINDATA   = 1;
 
-typedef int GREPCenter_t;
-const GREPCenter_t
+typedef int GREP_Center_t;
+const GREP_Center_t
    GREP_CENTER_BOX  = 0,
    GREP_CENTER_DENS = 1,
    GREP_CENTER_POT  = 2,

--- a/src/Auxiliary/Aux_Check_Parameter.cpp
+++ b/src/Auxiliary/Aux_Check_Parameter.cpp
@@ -1263,6 +1263,11 @@ void Aux_Check_Parameter()
 #     error : ERROR : GREP and UNSPLIT_GRAVITY are incompatible !!
 #  endif
 
+#  if ( EOS != EOS_NUCLEAR )
+   if ( GREP_OPT_PRES == GREP_PRES_BINDATA )
+      Aux_Error( ERROR_INFO, "unsupported parameter \"%s = %d\" when EOS != EOS_NUCLEAR !!\n", "GREP_OPT_PRES", GREP_OPT_PRES );
+#  endif
+
 #  else
    if ( OPT__EXT_POT == EXT_POT_GREP )
       Aux_Error( ERROR_INFO, "must enable GREP in the Makefile for OPT__EXT_POT == EXT_POT_GREP !!\n" );

--- a/src/Auxiliary/Aux_ComputeProfile.cpp
+++ b/src/Auxiliary/Aux_ComputeProfile.cpp
@@ -404,16 +404,25 @@ void Aux_ComputeProfile( Profile_t *Prof[], const double Center[], const double 
                                                   + FluWeighting_IntT*FluidPtr_IntT[DENS][k][j][i] )*dv
                                                 :                     FluidPtr     [DENS][k][j][i]  *dv;
 
-                              const real MomR   = ( FluIntTime )
-                                                ? ( FluWeighting     *( FluidPtr     [MOMX][k][j][i]*dx +
-                                                                        FluidPtr     [MOMY][k][j][i]*dy +
-                                                                        FluidPtr     [MOMZ][k][j][i]*dz )
-                                                  + FluWeighting_IntT*( FluidPtr_IntT[MOMX][k][j][i]*dx +
-                                                                        FluidPtr_IntT[MOMY][k][j][i]*dy +
-                                                                        FluidPtr_IntT[MOMZ][k][j][i]*dz ) ) / r
-                                                :                     ( FluidPtr     [MOMX][k][j][i]*dx +
-                                                                        FluidPtr     [MOMY][k][j][i]*dy +
-                                                                        FluidPtr     [MOMZ][k][j][i]*dz )   / r;
+                              real MomR;
+                              if ( r == 0 )
+                              {
+                                 MomR = (real)0.0;
+                              }
+
+                              else
+                              {
+                                 MomR   = ( FluIntTime )
+                                        ? ( FluWeighting     *( FluidPtr     [MOMX][k][j][i]*dx +
+                                                                FluidPtr     [MOMY][k][j][i]*dy +
+                                                                FluidPtr     [MOMZ][k][j][i]*dz )
+                                          + FluWeighting_IntT*( FluidPtr_IntT[MOMX][k][j][i]*dx +
+                                                                FluidPtr_IntT[MOMY][k][j][i]*dy +
+                                                                FluidPtr_IntT[MOMZ][k][j][i]*dz ) ) / r
+                                        :                     ( FluidPtr     [MOMX][k][j][i]*dx +
+                                                                FluidPtr     [MOMY][k][j][i]*dy +
+                                                                FluidPtr     [MOMZ][k][j][i]*dz )   / r;
+                              }
 
                               OMP_Data  [p][TID][bin] += MomR*dv;    // vr*(rho*dv)
                               OMP_Weight[p][TID][bin] += Weight;

--- a/src/Auxiliary/Aux_ComputeProfile.cpp
+++ b/src/Auxiliary/Aux_ComputeProfile.cpp
@@ -405,7 +405,7 @@ void Aux_ComputeProfile( Profile_t *Prof[], const double Center[], const double 
                                                 :                     FluidPtr     [DENS][k][j][i]  *dv;
 
                               real MomR;
-                              if ( r == 0 )
+                              if ( r == 0.0 )
                               {
                                  MomR = (real)0.0;
                               }

--- a/src/Auxiliary/Aux_TakeNote.cpp
+++ b/src/Auxiliary/Aux_TakeNote.cpp
@@ -1252,7 +1252,8 @@ void Aux_TakeNote()
       fprintf( Note, "GREP_LOGBINRATIO                %13.7e\n",  GREP_LOGBINRATIO        );
       fprintf( Note, "GREP_MAXRADIUS                  %13.7e\n",  GREP_MAXRADIUS          );
       fprintf( Note, "GREP_MINBINSIZE                 %13.7e\n",  GREP_MINBINSIZE         );
-      fprintf( Note, "GREP_OPT_FIXUP                  %d\n",      GREP_OPT_FIXUP          ); }
+      fprintf( Note, "GREP_OPT_FIXUP                  %d\n",      GREP_OPT_FIXUP          );
+      fprintf( Note, "GREP_OPT_PRES                   %d\n",      GREP_OPT_PRES           ); }
       fprintf( Note, "AveDensity_Init                 %13.7e\n",  AveDensity_Init         );
       fprintf( Note, "***********************************************************************************\n" );
       fprintf( Note, "\n\n");

--- a/src/Init/Init_ByRestart_HDF5.cpp
+++ b/src/Init/Init_ByRestart_HDF5.cpp
@@ -2002,6 +2002,7 @@ void Check_InputPara( const char *FileName, const int FormatVersion )
    LoadField( "GREP_MaxRadius",          &RS.GREP_MaxRadius,          SID, TID, NonFatal, &RT.GREP_MaxRadius,           1, NonFatal );
    LoadField( "GREP_MinBinSize",         &RS.GREP_MinBinSize,         SID, TID, NonFatal, &RT.GREP_MinBinSize,          1, NonFatal );
    LoadField( "GREP_Opt_FixUp",          &RS.GREP_Opt_FixUp,          SID, TID, NonFatal, &RT.GREP_Opt_FixUp,           1, NonFatal );
+   LoadField( "GREP_Opt_Pres",           &RS.GREP_Opt_Pres,           SID, TID, NonFatal, &RT.GREP_Opt_Pres,            1, NonFatal );
 #  endif // #ifdef GRAVITY
 
 // source terms

--- a/src/Init/Init_GAMER.cpp
+++ b/src/Init/Init_GAMER.cpp
@@ -269,6 +269,13 @@ void Init_GAMER( int *argc, char ***argv )
 //    evaluate the gravitational potential
       if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s ...\n", "Calculating gravitational potential" );
 
+
+//    utilize the box center as the reference point for GREP center during the initialization stage
+      const int Backup_GREP_Center = GREP_CENTER_METHOD;
+
+      if ( OPT__EXT_POT == EXT_POT_GREP )   GREP_CENTER_METHOD = GREP_CENTER_BOX;
+
+
       for (int lv=0; lv<NLEVEL; lv++)
       {
          if ( MPI_Rank == 0 )    Aux_Message( stdout, "   Lv %2d ... ", lv );
@@ -284,6 +291,10 @@ void Init_GAMER( int *argc, char ***argv )
       } // for (int lv=0; lv<NLEVEL; lv++)
 
       if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s ... done\n", "Calculating gravitational potential" );
+
+
+//    reset the GREP center
+      if ( OPT__EXT_POT == EXT_POT_GREP )   GREP_CENTER_METHOD = Backup_GREP_Center;
    } // if ( OPT__SELF_GRAVITY_TYPE  ||  OPT__EXT_POT )
 #  endif // #ifdef GARVITY
 

--- a/src/Init/Init_GAMER.cpp
+++ b/src/Init/Init_GAMER.cpp
@@ -271,7 +271,8 @@ void Init_GAMER( int *argc, char ***argv )
 
 
 //    utilize the box center as the reference point for GREP center during the initialization stage
-      const int Backup_GREP_Center = GREP_CENTER_METHOD;
+//    since the potential is not initialized yet
+      const GREP_Center_t Backup_GREP_Center = GREP_CENTER_METHOD;
 
       if ( OPT__EXT_POT == EXT_POT_GREP )   GREP_CENTER_METHOD = GREP_CENTER_BOX;
 
@@ -293,7 +294,7 @@ void Init_GAMER( int *argc, char ***argv )
       if ( MPI_Rank == 0 )    Aux_Message( stdout, "%s ... done\n", "Calculating gravitational potential" );
 
 
-//    reset the GREP center
+//    restore the GREP center
       if ( OPT__EXT_POT == EXT_POT_GREP )   GREP_CENTER_METHOD = Backup_GREP_Center;
    } // if ( OPT__SELF_GRAVITY_TYPE  ||  OPT__EXT_POT )
 #  endif // #ifdef GARVITY

--- a/src/Init/Init_Load_Parameter.cpp
+++ b/src/Init/Init_Load_Parameter.cpp
@@ -365,14 +365,14 @@ void Init_Load_Parameter()
 // fix EXT_POT_TABLE_FLOAT8 to -1 for now since this option is not supported yet
    ReadPara->Add( "EXT_POT_TABLE_FLOAT8",       &EXT_POT_TABLE_FLOAT8,           -1,              -1,            -1              );
    ReadPara->Add( "OPT__GRAVITY_EXTRA_MASS",    &OPT__GRAVITY_EXTRA_MASS,         false,           Useless_bool,  Useless_bool   );
-   ReadPara->Add( "GREP_CENTER_METHOD",         &GREP_CENTER_METHOD,              3,               1,             4              );
+   ReadPara->Add( "GREP_CENTER_METHOD",         &GREP_CENTER_METHOD,           GREP_CENTER_POT, GREP_CENTER_BOX, GREP_CENTER_COM );
    ReadPara->Add( "GREP_MAXITER",               &GREP_MAXITER,                    1000,            100,           NoMax_int      );
    ReadPara->Add( "GREP_LOGBIN",                &GREP_LOGBIN,                     true,            Useless_bool,  Useless_bool   );
    ReadPara->Add( "GREP_LOGBINRATIO",           &GREP_LOGBINRATIO,                1.25,            1.0,           NoMax_double   );
    ReadPara->Add( "GREP_MAXRADIUS",             &GREP_MAXRADIUS,                 -1.0,             NoMin_double,  NoMax_double   );
    ReadPara->Add( "GREP_MINBINSIZE",            &GREP_MINBINSIZE,                -1.0,             NoMin_double,  NoMax_double   );
    ReadPara->Add( "GREP_OPT_FIXUP",             &GREP_OPT_FIXUP,                  true,            Useless_bool,  Useless_bool   );
-   ReadPara->Add( "GREP_OPT_PRES",              &GREP_OPT_PRES,                   2,               1,             2              );
+   ReadPara->Add( "GREP_OPT_PRES",              &GREP_OPT_PRES,        GREP_PRES_BINDATA, GREP_PRES_INDIVCELL, GREP_PRES_BINDATA );
 #  endif // #ifdef GRAVITY
 
 

--- a/src/Init/Init_Load_Parameter.cpp
+++ b/src/Init/Init_Load_Parameter.cpp
@@ -365,7 +365,7 @@ void Init_Load_Parameter()
 // fix EXT_POT_TABLE_FLOAT8 to -1 for now since this option is not supported yet
    ReadPara->Add( "EXT_POT_TABLE_FLOAT8",       &EXT_POT_TABLE_FLOAT8,           -1,              -1,            -1              );
    ReadPara->Add( "OPT__GRAVITY_EXTRA_MASS",    &OPT__GRAVITY_EXTRA_MASS,         false,           Useless_bool,  Useless_bool   );
-   ReadPara->Add( "GREP_CENTER_METHOD",         &GREP_CENTER_METHOD,              0,               0,             3              );
+   ReadPara->Add( "GREP_CENTER_METHOD",         &GREP_CENTER_METHOD,              2,               0,             3              );
    ReadPara->Add( "GREP_MAXITER",               &GREP_MAXITER,                    1000,            100,           NoMax_int      );
    ReadPara->Add( "GREP_LOGBIN",                &GREP_LOGBIN,                     true,            Useless_bool,  Useless_bool   );
    ReadPara->Add( "GREP_LOGBINRATIO",           &GREP_LOGBINRATIO,                1.25,            1.0,           NoMax_double   );

--- a/src/Init/Init_Load_Parameter.cpp
+++ b/src/Init/Init_Load_Parameter.cpp
@@ -372,6 +372,7 @@ void Init_Load_Parameter()
    ReadPara->Add( "GREP_MAXRADIUS",            &GREP_MAXRADIUS,                  -1.0,             NoMin_double,   NoMax_double  );
    ReadPara->Add( "GREP_MINBINSIZE",           &GREP_MINBINSIZE,                 -1.0,             NoMin_double,   NoMax_double  );
    ReadPara->Add( "GREP_OPT_FIXUP",            &GREP_OPT_FIXUP,                   true,            Useless_bool,   Useless_bool  );
+   ReadPara->Add( "GREP_OPT_PRES",             &GREP_OPT_PRES,                    1,               0,              1             );
 #  endif // #ifdef GRAVITY
 
 

--- a/src/Init/Init_Load_Parameter.cpp
+++ b/src/Init/Init_Load_Parameter.cpp
@@ -365,14 +365,14 @@ void Init_Load_Parameter()
 // fix EXT_POT_TABLE_FLOAT8 to -1 for now since this option is not supported yet
    ReadPara->Add( "EXT_POT_TABLE_FLOAT8",       &EXT_POT_TABLE_FLOAT8,           -1,              -1,            -1              );
    ReadPara->Add( "OPT__GRAVITY_EXTRA_MASS",    &OPT__GRAVITY_EXTRA_MASS,         false,           Useless_bool,  Useless_bool   );
-   ReadPara->Add( "GREP_CENTER_METHOD",        &GREP_CENTER_METHOD,               1,               1,              1             );
-   ReadPara->Add( "GREP_MAXITER",              &GREP_MAXITER,                     1000,            100,            NoMax_int     );
-   ReadPara->Add( "GREP_LOGBIN",               &GREP_LOGBIN,                      true,            Useless_bool,   Useless_bool  );
-   ReadPara->Add( "GREP_LOGBINRATIO",          &GREP_LOGBINRATIO,                 1.25,            1.0,            NoMax_double  );
-   ReadPara->Add( "GREP_MAXRADIUS",            &GREP_MAXRADIUS,                  -1.0,             NoMin_double,   NoMax_double  );
-   ReadPara->Add( "GREP_MINBINSIZE",           &GREP_MINBINSIZE,                 -1.0,             NoMin_double,   NoMax_double  );
-   ReadPara->Add( "GREP_OPT_FIXUP",            &GREP_OPT_FIXUP,                   true,            Useless_bool,   Useless_bool  );
-   ReadPara->Add( "GREP_OPT_PRES",             &GREP_OPT_PRES,                    1,               0,              1             );
+   ReadPara->Add( "GREP_CENTER_METHOD",         &GREP_CENTER_METHOD,              0,               0,             3              );
+   ReadPara->Add( "GREP_MAXITER",               &GREP_MAXITER,                    1000,            100,           NoMax_int      );
+   ReadPara->Add( "GREP_LOGBIN",                &GREP_LOGBIN,                     true,            Useless_bool,  Useless_bool   );
+   ReadPara->Add( "GREP_LOGBINRATIO",           &GREP_LOGBINRATIO,                1.25,            1.0,           NoMax_double   );
+   ReadPara->Add( "GREP_MAXRADIUS",             &GREP_MAXRADIUS,                 -1.0,             NoMin_double,  NoMax_double   );
+   ReadPara->Add( "GREP_MINBINSIZE",            &GREP_MINBINSIZE,                -1.0,             NoMin_double,  NoMax_double   );
+   ReadPara->Add( "GREP_OPT_FIXUP",             &GREP_OPT_FIXUP,                  true,            Useless_bool,  Useless_bool   );
+   ReadPara->Add( "GREP_OPT_PRES",              &GREP_OPT_PRES,                   1,               0,             1              );
 #  endif // #ifdef GRAVITY
 
 

--- a/src/Init/Init_Load_Parameter.cpp
+++ b/src/Init/Init_Load_Parameter.cpp
@@ -365,14 +365,14 @@ void Init_Load_Parameter()
 // fix EXT_POT_TABLE_FLOAT8 to -1 for now since this option is not supported yet
    ReadPara->Add( "EXT_POT_TABLE_FLOAT8",       &EXT_POT_TABLE_FLOAT8,           -1,              -1,            -1              );
    ReadPara->Add( "OPT__GRAVITY_EXTRA_MASS",    &OPT__GRAVITY_EXTRA_MASS,         false,           Useless_bool,  Useless_bool   );
-   ReadPara->Add( "GREP_CENTER_METHOD",         &GREP_CENTER_METHOD,              2,               0,             3              );
+   ReadPara->Add( "GREP_CENTER_METHOD",         &GREP_CENTER_METHOD,              3,               1,             4              );
    ReadPara->Add( "GREP_MAXITER",               &GREP_MAXITER,                    1000,            100,           NoMax_int      );
    ReadPara->Add( "GREP_LOGBIN",                &GREP_LOGBIN,                     true,            Useless_bool,  Useless_bool   );
    ReadPara->Add( "GREP_LOGBINRATIO",           &GREP_LOGBINRATIO,                1.25,            1.0,           NoMax_double   );
    ReadPara->Add( "GREP_MAXRADIUS",             &GREP_MAXRADIUS,                 -1.0,             NoMin_double,  NoMax_double   );
    ReadPara->Add( "GREP_MINBINSIZE",            &GREP_MINBINSIZE,                -1.0,             NoMin_double,  NoMax_double   );
    ReadPara->Add( "GREP_OPT_FIXUP",             &GREP_OPT_FIXUP,                  true,            Useless_bool,  Useless_bool   );
-   ReadPara->Add( "GREP_OPT_PRES",              &GREP_OPT_PRES,                   1,               0,             1              );
+   ReadPara->Add( "GREP_OPT_PRES",              &GREP_OPT_PRES,                   2,               1,             2              );
 #  endif // #ifdef GRAVITY
 
 

--- a/src/Init/Init_ResetParameter.cpp
+++ b/src/Init/Init_ResetParameter.cpp
@@ -1027,7 +1027,7 @@ void Init_ResetParameter()
 #  endif
 
 
-// must set OPT__FFTW_STARTUP = FFTW_STARTUP_ESTIMATE for BITWISE_REPRODUCIBILITY 
+// must set OPT__FFTW_STARTUP = FFTW_STARTUP_ESTIMATE for BITWISE_REPRODUCIBILITY
 // --> even when disabling BITWISE_REPRODUCIBILITY, we still use FFTW_STARTUP_ESTIMATE
 //     by default since otherwise the FFT results can vary in each run on the level
 //     of machine precision, which can be confusing
@@ -1042,6 +1042,24 @@ void Init_ResetParameter()
       OPT__FFTW_STARTUP = FFTW_STARTUP_ESTIMATE;
       PRINT_WARNING( OPT__FFTW_STARTUP, FORMAT_INT, "when disabling BITWISE_REPRODUCIBILITY" );
 #     endif
+   }
+#  endif
+
+
+// GREP
+#  ifdef GRAVITY
+   if ( GREP_MINBINSIZE <= 0.0 )
+   {
+      GREP_MINBINSIZE = amr->dh[MAX_LEVEL];
+
+      PRINT_WARNING( GREP_MINBINSIZE, FORMAT_FLT, "" );
+   }
+
+   if ( GREP_MAXRADIUS <= 0.0 )
+   {
+      GREP_MAXRADIUS = sqrt(3.0) * amr->BoxSize[0];
+
+      PRINT_WARNING( GREP_MAXRADIUS, FORMAT_FLT, "" );
    }
 #  endif
 

--- a/src/Main/Main.cpp
+++ b/src/Main/Main.cpp
@@ -273,6 +273,7 @@ double GREP_LOGBINRATIO;
 double GREP_MAXRADIUS;
 double GREP_MINBINSIZE;
 bool   GREP_OPT_FIXUP;
+int    GREP_OPT_PRES;
 
 // (2-11) source terms
 SrcTerms_t SrcTerms;

--- a/src/Main/Main.cpp
+++ b/src/Main/Main.cpp
@@ -160,6 +160,16 @@ ExtPot_t CPUExtPot_Ptr = NULL;
 ExtAcc_t GPUExtAcc_Ptr = NULL;
 ExtPot_t GPUExtPot_Ptr = NULL;
 #endif
+
+// GREP
+GREP_Center_t        GREP_CENTER_METHOD;
+int                  GREP_MAXITER;
+bool                 GREP_LOGBIN;
+double               GREP_LOGBINRATIO;
+double               GREP_MAXRADIUS;
+double               GREP_MINBINSIZE;
+bool                 GREP_OPT_FIXUP;
+GREP_PresScheme_t    GREP_OPT_PRES;
 #endif // #ifdef GRAVITY
 
 // (2-3) cosmological simulations
@@ -265,17 +275,7 @@ Nuc_IntScheme_t NUC_INT_SCHEME_MAIN;
 #endif
 #endif // HYDRO
 
-// (2-10) GREP
-int    GREP_CENTER_METHOD;
-int    GREP_MAXITER;
-bool   GREP_LOGBIN;
-double GREP_LOGBINRATIO;
-double GREP_MAXRADIUS;
-double GREP_MINBINSIZE;
-bool   GREP_OPT_FIXUP;
-int    GREP_OPT_PRES;
-
-// (2-11) source terms
+// (2-10) source terms
 SrcTerms_t SrcTerms;
 #if ( MODEL == HYDRO )
 double     Src_Dlep_AuxArray_Flt     [SRC_NAUX_DLEP     ];

--- a/src/Output/Output_DumpData_Total_HDF5.cpp
+++ b/src/Output/Output_DumpData_Total_HDF5.cpp
@@ -2305,6 +2305,7 @@ void FillIn_InputPara( InputPara_t &InputPara, const int NFieldStored, char Fiel
    InputPara.GREP_MaxRadius          = GREP_MAXRADIUS;
    InputPara.GREP_MinBinSize         = GREP_MINBINSIZE;
    InputPara.GREP_Opt_FixUp          = GREP_OPT_FIXUP;
+   InputPara.GREP_Opt_Pres           = GREP_OPT_PRES;
 #  endif // #ifdef GRAVITY
 
 // source terms
@@ -3218,6 +3219,7 @@ void GetCompound_InputPara( hid_t &H5_TypeID, const int NFieldStored )
    H5Tinsert( H5_TypeID, "GREP_MaxRadius",          HOFFSET(InputPara_t,GREP_MaxRadius         ), H5T_NATIVE_DOUBLE  );
    H5Tinsert( H5_TypeID, "GREP_MinBinSize",         HOFFSET(InputPara_t,GREP_MinBinSize        ), H5T_NATIVE_DOUBLE  );
    H5Tinsert( H5_TypeID, "GREP_Opt_FixUp",          HOFFSET(InputPara_t,GREP_Opt_FixUp         ), H5T_NATIVE_INT     );
+   H5Tinsert( H5_TypeID, "GREP_Opt_Pres",           HOFFSET(InputPara_t,GREP_Opt_Pres          ), H5T_NATIVE_INT     );
 #  endif // #ifdef GRAVITY
 
 // source terms

--- a/src/SelfGravity/CPU_Poisson/CPU_ComputeGREP.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_ComputeGREP.cpp
@@ -9,14 +9,25 @@
 //
 // Note        :  1. Enabled if macro GRAVITY and GREP are set
 //                2. Invoked by Poi_UserWorkBeforePoisson_GREP()
-//                3. The profile Phi_eff stores the value of -Phi_NW(r) + Phi_TOV(r) at the bin center
+//                3. The profile EffPot stores the value of -Phi_NW(r) + Phi_TOV(r) at the bin center
 //                4. Ref: Marek et al., 2006, A&A, 445, 273 (arXiv: 0502161), sec. 2, case A
+//
+// Parameter   :  lv      : Current AMR level
+//                Time    : Current physical time at the refinement level=lv
+//                DensAve : Profile_t object storing the spherically averaged profile of density
+//                EngyAve : Profile_t object storing the spherically averaged profile of internal energy density
+//                VrAve   : Profile_t object storing the spherically averaged profile of radial velocity
+//                PresAve : Profile_t object storing the spherically averaged profile of pressure
+//                EffPot  : Profile_t object storing the effective GR potential
+//
+// Return      :  EffPot
 //-------------------------------------------------------------------------------------------------------
 void CPU_ComputeGREP( const int lv, const double Time, const Profile_t *DensAve, const Profile_t *EngyAve,
-                      const Profile_t *VrAve, const Profile_t *PresAve, Profile_t *Phi_eff )
+                      const Profile_t *VrAve, const Profile_t *PresAve, Profile_t *EffPot )
 {
 
    const double c2          = SQR( Const_c / UNIT_V );
+   const double _c2         = 1.0 / c2;
    const double FourPI      = 4.0 * M_PI;
    const double FourThirdPI = FourPI / 3.0;
    const double Tolerance   = 1.0e-5;
@@ -63,7 +74,7 @@ void CPU_ComputeGREP( const int lv, const double Time, const Profile_t *DensAve,
    while ( ! IsConverged  &&  ( NIter++ < GREP_MAXITER ) )
    {
 //    update Mass_TOV
-      for (int i=0; i<NBin;   i++)   Dens_TOV[i] = Gamma_TOV[i] * ( Dens[i] + Engy[i] / c2 );
+      for (int i=0; i<NBin;   i++)   Dens_TOV[i] = Gamma_TOV[i] * ( Dens[i] + Engy[i] * _c2 );
 
                                      Mass_TOV     [0] = dVol     [0] * Dens_TOV[0];
       for (int i=1; i<NBin-1; i++)   Mass_TOV     [i] = dVol     [i] * ( 0.5 * Dens_TOV[i] + 0.25 * ( Dens_TOV[i-1] + Dens_TOV[i+1] ) );
@@ -73,9 +84,9 @@ void CPU_ComputeGREP( const int lv, const double Time, const Profile_t *DensAve,
 
 //    update Gamma_TOV
       for (int i=0; i<NBin-1; i++)   Gamma_TOV     [i] = 1.0 + ( 0.25 * SQR( Vr[i] + Vr[i+1] )
-                                                               - 2.0  * NEWTON_G * Mass_TOV[i]      / EdgeL[i+1]  ) / c2;
+                                                               - 2.0  * NEWTON_G * Mass_TOV[i]      / EdgeL[i+1]  ) * _c2;
                                      Gamma_TOV[NBin-1] = 1.0 + (        SQR( Vr[NBin-1] )
-                                                               - 2.0  * NEWTON_G * Mass_TOV[NBin-1] / MaxRadius   ) / c2;
+                                                               - 2.0  * NEWTON_G * Mass_TOV[NBin-1] / MaxRadius   ) * _c2;
 
       for (int i=0; i<NBin;   i++)   Gamma_TOV[i] = sqrt( MAX( TINY_NUMBER, Gamma_TOV[i] ) );
 
@@ -104,106 +115,106 @@ void CPU_ComputeGREP( const int lv, const double Time, const Profile_t *DensAve,
    {
       if ( MPI_Rank == 0 )
       {
-         char FileName_GREP[50];
+         char FileName[MAX_STRING];
 
-         sprintf( FileName_GREP, "GREP_Lv%02d_Debug", lv );
-         FILE *File_GREP = fopen( FileName_GREP, "w" );
+         sprintf( FileName, "GREP_Lv%02d_FailedTOVProfile", lv );
+         FILE *File = fopen( FileName, "w" );
 
 //       metadata
-         fprintf( File_GREP, "# Step               : %ld\n",                  Step );
-         fprintf( File_GREP, "# Time               : %.7e\n",                 Time );
-         fprintf( File_GREP, "# GREP_CENTER_METHOD : %d\n",                   GREP_CENTER_METHOD );
-         fprintf( File_GREP, "# Center             : %13.7e %13.7e %13.7e\n", DensAve->Center[0], DensAve->Center[1], DensAve->Center[2] );
-         fprintf( File_GREP, "# Maximum Radius     : %13.7e\n",               DensAve->MaxRadius );
-         fprintf( File_GREP, "# LogBin             : %d\n",                   DensAve->LogBin );
-         fprintf( File_GREP, "# LogBinRatio        : %13.7e\n",               DensAve->LogBinRatio );
-         fprintf( File_GREP, "# NBin               : %d\n",                   NBin );
-         fprintf( File_GREP, "# Maximum Iteration  : %d\n",                   GREP_MAXITER );
-         fprintf( File_GREP, "# Tolerance          : %13.7e\n",               Tolerance );
-         fprintf( File_GREP, "------------------------------------------------------\n" );
-         fprintf( File_GREP, "%5s %9s %22s %22s %22s %22s %22s %22s %22s %22s %22s %22s\n",
-                             "# Bin", "NCell", "Radius", "Dens", "Engy", "Vr", "Pressure",
-                             "Mass_NW", "Mass_TOV", "Mass_TOV_Usg", "Gamma_TOV", "Rel_Err (Mass_TOV)");
+         fprintf( File, "# Step               : %ld\n",                  Step );
+         fprintf( File, "# Time               : %.7e\n",                 Time );
+         fprintf( File, "# GREP_CENTER_METHOD : %d\n",                   GREP_CENTER_METHOD );
+         fprintf( File, "# Center             : %13.7e %13.7e %13.7e\n", DensAve->Center[0], DensAve->Center[1], DensAve->Center[2] );
+         fprintf( File, "# Maximum Radius     : %13.7e\n",               DensAve->MaxRadius );
+         fprintf( File, "# LogBin             : %d\n",                   DensAve->LogBin );
+         fprintf( File, "# LogBinRatio        : %13.7e\n",               DensAve->LogBinRatio );
+         fprintf( File, "# NBin               : %d\n",                   NBin );
+         fprintf( File, "# Maximum Iteration  : %d\n",                   GREP_MAXITER );
+         fprintf( File, "# Tolerance          : %13.7e\n",               Tolerance );
+         fprintf( File, "------------------------------------------------------\n" );
+         fprintf( File, "%5s %9s %22s %22s %22s %22s %22s %22s %22s %22s %22s %22s\n",
+                        "# Bin", "NCell", "Radius", "Density", "Energy", "Vr", "Pressure",
+                        "Mass_NW", "Mass_TOV", "Mass_TOV_Usg", "Gamma_TOV", "Rel_Err (Mass_TOV)");
 
 //       data
          for (int i=0; i<NBin; i++)
-         fprintf( File_GREP, "%5d %9ld %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e\n",
-                             i, DensAve->NCell[i], Radius[i], Dens[i], Engy[i], Vr[i], Pres[i],
-                             Mass_NW[i], Mass_TOV[i], Mass_TOV_USG[i], Gamma_TOV[i],
-                             fabs( Mass_TOV_USG[i] - Mass_TOV[i] ) / Mass_TOV[i] );
+         fprintf( File, "%5d %9ld %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e\n",
+                        i, DensAve->NCell[i], Radius[i], Dens[i], Engy[i], Vr[i], Pres[i],
+                        Mass_NW[i], Mass_TOV[i], Mass_TOV_USG[i], Gamma_TOV[i],
+                        fabs( Mass_TOV_USG[i] - Mass_TOV[i] ) / Mass_TOV[i] );
 
-         fclose( File_GREP );
+         fclose( File );
 
 //       terminate the program
-         Aux_Error( ERROR_INFO, "The solutions for Mass_TOV and Gamma_TOV are not converging !!\n" );
+         Aux_Error( ERROR_INFO, "the solutions for Mass_TOV and Gamma_TOV are not converging !!\n" );
       }
    } // if ( ! IsConverged )
 
 
 // 3. compute the effective GR potential at the bin center
-   Phi_eff->NBin        = DensAve->NBin;
-   Phi_eff->LogBin      = DensAve->LogBin;
-   Phi_eff->LogBinRatio = DensAve->LogBinRatio;
-   Phi_eff->MaxRadius   = DensAve->MaxRadius;
-   Phi_eff->AllocateMemory();
+   EffPot->NBin        = DensAve->NBin;
+   EffPot->LogBin      = DensAve->LogBin;
+   EffPot->LogBinRatio = DensAve->LogBinRatio;
+   EffPot->MaxRadius   = DensAve->MaxRadius;
+   EffPot->AllocateMemory();
 
-   for (int d=0; d<3;    d++)   Phi_eff->Center[d] = DensAve->Center[d];
-   for (int b=0; b<NBin; b++)   Phi_eff->Radius[b] = DensAve->Radius[b];
+   for (int d=0; d<3;    d++)   EffPot->Center[d] = DensAve->Center[d];
+   for (int b=0; b<NBin; b++)   EffPot->Radius[b] = DensAve->Radius[b];
 
 // set the outer boundary condition of the potential to -G * M_out / r_out
-   Phi_eff->Data[NBin-1] = -NEWTON_G * ( Mass_TOV[NBin-1] - Mass_NW[NBin-1] ) / Radius[NBin-1];
+   EffPot->Data[NBin-1] = -NEWTON_G * ( Mass_TOV[NBin-1] - Mass_NW[NBin-1] ) / Radius[NBin-1];
 
    for (int i=NBin-2; i>0; i--)
    {
       double dr         = Radius[i] - Radius[i+1];
       double Mass_NW_C  = 0.5 * ( Mass_NW[i] + Mass_NW[i-1] );
-      double Mass_TOV_C = ( 0.5 * ( Mass_TOV[i] + Mass_TOV[i-1] ) + FourPI * CUBE( Radius[i] ) * Pres[i] / c2 )
+      double Mass_TOV_C = ( 0.5 * ( Mass_TOV[i] + Mass_TOV[i-1] ) + FourPI * CUBE( Radius[i] ) * Pres[i] * _c2 )
                         * ( 1.0 + ( Engy[i] + Pres[i] ) / ( Dens[i] * c2 ) )
                         / SQR( 0.5 * ( Gamma_TOV[i] + Gamma_TOV[i-1] ) );
 
-      Phi_eff->Data[i] = Phi_eff->Data[i+1] - dr * NEWTON_G * ( Mass_NW_C - Mass_TOV_C ) / SQR( Radius[i] );
+      EffPot->Data[i] = EffPot->Data[i+1] - dr * NEWTON_G * ( Mass_NW_C - Mass_TOV_C ) / SQR( Radius[i] );
    }
 
    double dr         = Radius[0] - Radius[1];
    double Mass_NW_C  = Mass_NW[0];
-   double Mass_TOV_C = ( Mass_TOV[0] + FourPI * CUBE( Radius[0] ) * Pres[0] / c2 )
+   double Mass_TOV_C = ( Mass_TOV[0] + FourPI * CUBE( Radius[0] ) * Pres[0] * _c2 )
                      * ( 1.0 + ( Engy[0] + Pres[0] ) / ( Dens[0] * c2 ) )
                      / SQR( Gamma_TOV[0] );
 
-   Phi_eff->Data[0] = Phi_eff->Data[1] - dr * NEWTON_G * ( Mass_NW_C - Mass_TOV_C ) / SQR( Radius[0] ) ;
+   EffPot->Data[0] = EffPot->Data[1] - dr * NEWTON_G * ( Mass_NW_C - Mass_TOV_C ) / SQR( Radius[0] ) ;
 
 
 // troubleshooting information
 #  ifdef GAMER_DEBUG
    if ( MPI_Rank == 0 )
    {
-      char FileName_GREP[50];
+      char FileName[MAX_STRING];
 
-      sprintf( FileName_GREP, "GREP_Lv%02d", lv );
-      FILE *File_GREP = fopen( FileName_GREP, "w" );
+      sprintf( FileName, "GREP_Lv%02d", lv );
+      FILE *File = fopen( FileName, "w" );
 
 //    metadata
-      fprintf( File_GREP, "# Step               : %ld\n",                  Step );
-      fprintf( File_GREP, "# Time               : %.7e\n",                 Time );
-      fprintf( File_GREP, "# GREP_CENTER_METHOD : %d\n",                   GREP_CENTER_METHOD );
-      fprintf( File_GREP, "# Center             : %13.7e %13.7e %13.7e\n", Phi_eff->Center[0], Phi_eff->Center[1], Phi_eff->Center[2] );
-      fprintf( File_GREP, "# Maximum Radius     : %13.7e\n",               Phi_eff->MaxRadius );
-      fprintf( File_GREP, "# LogBin             : %d\n",                   Phi_eff->LogBin );
-      fprintf( File_GREP, "# LogBinRatio        : %13.7e\n",               Phi_eff->LogBinRatio );
-      fprintf( File_GREP, "# Num of Iteration   : %d\n",                   NIter );
-      fprintf( File_GREP, "# NBin               : %d\n",                   NBin );
-      fprintf( File_GREP, "# -----------------------------------------------\n" );
-      fprintf( File_GREP, "%5s %9s %22s %22s %22s %22s %22s %22s %22s %22s %23s\n",
-                          "# Bin", "NCell", "Radius", "Dens", "Engy", "Vr", "Pressure",
-                          "Mass_NW", "Mass_TOV", "Gamma_TOV", "Eff_Pot");
+      fprintf( File, "# Step                 : %ld\n",                  Step );
+      fprintf( File, "# Time                 : %.7e\n",                 Time );
+      fprintf( File, "# GREP_CENTER_METHOD   : %d\n",                   GREP_CENTER_METHOD );
+      fprintf( File, "# Center               : %13.7e %13.7e %13.7e\n", EffPot->Center[0], EffPot->Center[1], EffPot->Center[2] );
+      fprintf( File, "# Maximum Radius       : %13.7e\n",               EffPot->MaxRadius );
+      fprintf( File, "# LogBin               : %d\n",                   EffPot->LogBin );
+      fprintf( File, "# LogBinRatio          : %13.7e\n",               EffPot->LogBinRatio );
+      fprintf( File, "# Number of Iterations : %d\n",                   NIter );
+      fprintf( File, "# NBin                 : %d\n",                   NBin );
+      fprintf( File, "# -------------------------------------------------\n" );
+      fprintf( File, "%5s %9s %22s %22s %22s %22s %22s %22s %22s %22s %23s\n",
+                     "# Bin", "NCell", "Radius", "Density", "Energy", "Vr", "Pressure",
+                     "Mass_NW", "Mass_TOV", "Gamma_TOV", "Eff_Pot");
 
 //    data
       for (int i=0; i<NBin; i++)
-      fprintf( File_GREP, "%5d %9ld %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %23.15e\n",
-                          i, DensAve->NCell[i], Radius[i], Dens[i], Engy[i], Vr[i], Pres[i],
-                          Mass_NW[i], Mass_TOV[i], Gamma_TOV[i], Phi_eff->Data[i] );
+      fprintf( File, "%5d %9ld %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %23.15e\n",
+                     i, DensAve->NCell[i], Radius[i], Dens[i], Engy[i], Vr[i], Pres[i],
+                     Mass_NW[i], Mass_TOV[i], Gamma_TOV[i], EffPot->Data[i] );
 
-      fclose( File_GREP );
+      fclose( File );
    }
 #  endif
 

--- a/src/SelfGravity/CPU_Poisson/CPU_ComputeGREP.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_ComputeGREP.cpp
@@ -19,10 +19,9 @@ void CPU_ComputeGREP( const int lv, const double Time, const Profile_t *DensAve,
    const double c2          = SQR( Const_c / UNIT_V );
    const double FourPI      = 4.0 * M_PI;
    const double FourThirdPI = FourPI / 3.0;
-   const double Tolerance   = 1.e-5;
+   const double Tolerance   = 1.0e-5;
 
    int     NIter     = 0;
-   int     NIter_Max = GREP_MAXITER;
    int     NBin      = DensAve->NBin;
    double *Radius    = DensAve->Radius;
    double  MaxRadius = DensAve->MaxRadius;
@@ -61,7 +60,7 @@ void CPU_ComputeGREP( const int lv, const double Time, const Profile_t *DensAve,
 // 2. iteratively compute Mass_TOV and Gamma_TOV at the outer edge of each bin
    bool IsConverged = false;
 
-   while ( ! IsConverged  &&  ( NIter++ < NIter_Max ) )
+   while ( ! IsConverged  &&  ( NIter++ < GREP_MAXITER ) )
    {
 //    update Mass_TOV
       for (int i=0; i<NBin;   i++)   Dens_TOV[i] = Gamma_TOV[i] * ( Dens[i] + Engy[i] / c2 );
@@ -97,7 +96,7 @@ void CPU_ComputeGREP( const int lv, const double Time, const Profile_t *DensAve,
 //    backup the old Mass_TOV if not converged yet
       if ( ! IsConverged )
          for (int i=0; i<NBin; i++)   Mass_TOV_USG[i] = Mass_TOV[i];
-   } // while ( ! IsConverged  &&  ( NIter++ < NIter_Max ) )
+   } // while ( ! IsConverged  &&  ( NIter++ < GREP_MAXITER ) )
 
 
 // troubleshooting information in case convergent solutions cannot be found.
@@ -119,7 +118,7 @@ void CPU_ComputeGREP( const int lv, const double Time, const Profile_t *DensAve,
          fprintf( File_GREP, "# LogBin             : %d\n",                   DensAve->LogBin );
          fprintf( File_GREP, "# LogBinRatio        : %13.7e\n",               DensAve->LogBinRatio );
          fprintf( File_GREP, "# NBin               : %d\n",                   NBin );
-         fprintf( File_GREP, "# Maximum Iteration  : %d\n",                   NIter_Max );
+         fprintf( File_GREP, "# Maximum Iteration  : %d\n",                   GREP_MAXITER );
          fprintf( File_GREP, "# Tolerance          : %13.7e\n",               Tolerance );
          fprintf( File_GREP, "------------------------------------------------------\n" );
          fprintf( File_GREP, "%5s %9s %22s %22s %22s %22s %22s %22s %22s %22s %22s %22s\n",

--- a/src/SelfGravity/CPU_Poisson/CPU_ComputeGREP.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_ComputeGREP.cpp
@@ -100,7 +100,7 @@ void CPU_ComputeGREP( const int lv, const double Time, const Profile_t *DensAve,
    } // while ( ! IsConverged  &&  ( NIter++ < NIter_Max ) )
 
 
-// Troubleshooting information in case convergent solutions cannot be found.
+// troubleshooting information in case convergent solutions cannot be found.
    if ( ! IsConverged )
    {
       if ( MPI_Rank == 0 )
@@ -174,7 +174,7 @@ void CPU_ComputeGREP( const int lv, const double Time, const Profile_t *DensAve,
    Phi_eff->Data[0] = Phi_eff->Data[1] - dr * NEWTON_G * ( Mass_NW_C - Mass_TOV_C ) / SQR( Radius[0] ) ;
 
 
-// Troubleshooting information
+// troubleshooting information
 #  ifdef GAMER_DEBUG
    if ( MPI_Rank == 0 )
    {

--- a/src/SelfGravity/CPU_Poisson/CPU_ComputeGREP.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_ComputeGREP.cpp
@@ -12,189 +12,201 @@
 //                3. The profile Phi_eff stores the value of -Phi_NW(r) + Phi_TOV(r) at the bin center
 //                4. Ref: Marek et al., 2006, A&A, 445, 273 (arXiv: 0502161), sec. 2, case A
 //-------------------------------------------------------------------------------------------------------
-void CPU_ComputeGREP( const Profile_t *DensAve, const Profile_t *EngyAve, const Profile_t *VrAve,
-                      const Profile_t *PresAve, Profile_t *Phi_eff )
+void CPU_ComputeGREP( const int lv, const double Time, const Profile_t *DensAve, const Profile_t *EngyAve,
+                      const Profile_t *VrAve, const Profile_t *PresAve, Profile_t *Phi_eff )
 {
 
-   const double c2          = SQR( Const_c/UNIT_V );
-   const double FourPI      = 4.0*M_PI;
-   const double FourThirdPI = FourPI/3.0;
-   const double tolerance   = 1.e-5;
+   const double c2          = SQR( Const_c / UNIT_V );
+   const double FourPI      = 4.0 * M_PI;
+   const double FourThirdPI = FourPI / 3.0;
+   const double Tolerance   = 1.e-5;
 
-   int     NIter     = GREP_MAXITER;
+   int     NIter     = 0;
+   int     NIter_Max = GREP_MAXITER;
    int     NBin      = DensAve->NBin;
    double *Radius    = DensAve->Radius;
    double  MaxRadius = DensAve->MaxRadius;
+   double *Dens      = DensAve->Data;
+   double *Engy      = EngyAve->Data;
+   double *Vr        = VrAve  ->Data;
+   double *Pres      = PresAve->Data;
 
-   double *Mass_NW, *Mass_TOV, *Mass_TOV_USG, *Dens_TOV, *Gamma_TOV, *dVol, *EdgeL;
-
-   Mass_NW      = new double [NBin];  // Newtonian mass for \bar_Phi(r)     in Eq. (7) in Marek+ (2006)
-   Mass_TOV     = new double [NBin];  // TOV mass       for \bar_Phi(r)_TOV in Eq. (7) in Marek+ (2006)
-   Mass_TOV_USG = new double [NBin];  // TOV mass before update
-   Dens_TOV     = new double [NBin];  // empirical TOV density                 Eq. (4) in Marek+ (2006)
-   Gamma_TOV    = new double [NBin];  // metric function                       Eq. (5) in Marek+ (2006)
-   dVol         = new double [NBin];
-   EdgeL        = new double [NBin];
+   double *Mass_NW      = new double [NBin];  // enclosed Newtonian mass for \bar_Phi(r)     in Eq. (7)
+   double *Mass_TOV     = new double [NBin];  // enclosed TOV mass       for \bar_Phi(r)_TOV in Eq. (7)
+   double *Mass_TOV_USG = new double [NBin];  // enclosed TOV mass in the previous iteration
+   double *Dens_TOV     = new double [NBin];  // empirical TOV density                          Eq. (4)
+   double *Gamma_TOV    = new double [NBin];  // metric function                                Eq. (5)
+   double *dVol         = new double [NBin];  // volume    of each bin
+   double *EdgeL        = new double [NBin];  // left edge of each bin
 
    for (int i=0; i<NBin;   i++)   Mass_TOV_USG[i] = 0.0;
    for (int i=0; i<NBin;   i++)   Gamma_TOV   [i] = 1.0;
 
+                                  EdgeL       [0] = 0.0;
    for (int i=1; i<NBin;   i++)   EdgeL       [i] = ( GREP_LOGBIN ) ? sqrt( Radius[i-1] * Radius[i] )
                                                                     : 0.5*( Radius[i-1] + Radius[i] );
-   EdgeL[0] = 0.0;
 
-   for (int i=0; i<NBin-1; i++)   dVol        [i] = FourThirdPI * ( CUBE( EdgeL[i+1] ) - CUBE( EdgeL[i] ) );
-
-   dVol[NBin-1] = FourThirdPI * ( CUBE( MaxRadius ) - CUBE( EdgeL[NBin-1] ) );
+   for (int i=0; i<NBin-1; i++)   dVol        [i] = FourThirdPI * ( CUBE( EdgeL[i+1] ) - CUBE( EdgeL[i]      ) );
+                                  dVol   [NBin-1] = FourThirdPI * ( CUBE( MaxRadius  ) - CUBE( EdgeL[NBin-1] ) );
 
 
-// compute Mass_NW defined at the outer edge of bin
-   Mass_NW[0] = dVol[0] * DensAve->Data[0];
+// 1. compute Mass_NW at the outer edge of each bin
+                                  Mass_NW     [0] = dVol     [0] * Dens[0];
+   for (int i=1; i<NBin-1; i++)   Mass_NW     [i] = dVol     [i] * ( 0.5 * Dens[i] + 0.25 * ( Dens[i-1] + Dens[i+1] ) );
+                                  Mass_NW[NBin-1] = dVol[NBin-1] * Dens[NBin-1];
 
-   for (int i=1; i<NBin-1; i++)
-      Mass_NW[i] = Mass_NW[i-1]
-                 + dVol[i] * ( 0.5 * DensAve->Data[i] + 0.25 * ( DensAve->Data[i-1] + DensAve->Data[i+1] ) );
-
-   Mass_NW[NBin-1] = Mass_NW[NBin-2] + dVol[NBin-1] * DensAve->Data[NBin-1];
+   for (int i=1; i<NBin;   i++)   Mass_NW[i] += Mass_NW[i-1];
 
 
-// iteratively compute Mass_TOV and Gamma_TOV defined at the outer edge of bin
-   while ( NIter-- )
+// 2. iteratively compute Mass_TOV and Gamma_TOV at the outer edge of each bin
+   bool IsConverged = false;
+
+   while ( ! IsConverged  &&  ( NIter++ < NIter_Max ) )
    {
+//    update Mass_TOV
+      for (int i=0; i<NBin;   i++)   Dens_TOV[i] = Gamma_TOV[i] * ( Dens[i] + Engy[i] / c2 );
 
-      for (int i=0; i<NBin; i++)
-         Dens_TOV[i] = Gamma_TOV[i] * ( DensAve->Data[i] + EngyAve->Data[i] / c2 );
+                                     Mass_TOV     [0] = dVol     [0] * Dens_TOV[0];
+      for (int i=1; i<NBin-1; i++)   Mass_TOV     [i] = dVol     [i] * ( 0.5 * Dens_TOV[i] + 0.25 * ( Dens_TOV[i-1] + Dens_TOV[i+1] ) );
+                                     Mass_TOV[NBin-1] = dVol[NBin-1] * Dens_TOV[NBin-1];
 
+      for (int i=1; i<NBin  ; i++)   Mass_TOV[i] += Mass_TOV[i-1];
 
-//    compute Mass_TOV
-      Mass_TOV[0] = dVol[0] * Dens_TOV[0];
+//    update Gamma_TOV
+      for (int i=0; i<NBin-1; i++)   Gamma_TOV     [i] = 1.0 + ( 0.25 * SQR( Vr[i] + Vr[i+1] )
+                                                               - 2.0  * NEWTON_G * Mass_TOV[i]      / EdgeL[i+1]  ) / c2;
+                                     Gamma_TOV[NBin-1] = 1.0 + (        SQR( Vr[NBin-1] )
+                                                               - 2.0  * NEWTON_G * Mass_TOV[NBin-1] / MaxRadius   ) / c2;
 
-      for (int i=1; i<NBin-1; i++)
-         Mass_TOV[i] = Mass_TOV[i-1]
-                     + dVol[i] * ( 0.5 * Dens_TOV[i] + 0.25 * ( Dens_TOV[i-1] + Dens_TOV[i+1] ) );
+      for (int i=0; i<NBin;   i++)   Gamma_TOV[i] = sqrt( MAX( TINY_NUMBER, Gamma_TOV[i] ) );
 
-      Mass_TOV[NBin-1] = Mass_TOV[NBin-2] + dVol[NBin-1] * Dens_TOV[NBin-1];
+//    check whether the Mass_TOV is converged
+      IsConverged = true;
 
-
-//    compute Gamma_TOV
-      for (int i=0; i<NBin-1; i++)
-           Gamma_TOV[i] = SQRT( MAX( TINY_NUMBER,
-                                     1.0 + ( 0.25 * SQR( VrAve->Data[i] + VrAve->Data[i+1] )
-                                           - 2.0  * NEWTON_G * Mass_TOV[i]      / EdgeL[i+1]  ) / c2 ) );
-
-      Gamma_TOV[NBin-1] = SQRT( MAX( TINY_NUMBER,
-                                     1.0 + (        SQR( VrAve->Data[NBin-1] )
-                                           - 2.0 *  NEWTON_G * Mass_TOV[NBin-1] / MaxRadius   ) / c2 ) );
-
-
-//    check whether the tolerance is satisfied
-      bool Pass = true;
       for (int i=0; i<NBin; i++)
       {
-         double error = FABS( Mass_TOV_USG[i] - Mass_TOV[i] ) / Mass_TOV[i];
+         double RelErr = fabs( Mass_TOV_USG[i] - Mass_TOV[i] ) / Mass_TOV[i];
 
-         if ( error > tolerance )
+         if ( RelErr > Tolerance )
          {
-            Pass = false;
+            IsConverged = false;
             break;
          }
       }
 
-      if ( Pass )   break;
-      else          for (int i=0; i<NBin; i++)   Mass_TOV_USG[i] = Mass_TOV[i];
+//    backup the old Mass_TOV if not converged yet
+      if ( ! IsConverged )
+         for (int i=0; i<NBin; i++)   Mass_TOV_USG[i] = Mass_TOV[i];
+   } // while ( ! IsConverged  &&  ( NIter++ < NIter_Max ) )
 
 
-//    additional information for debug if no convegent solution is found
-      if ( !NIter  &&  !Pass )
+// Troubleshooting information in case convergent solutions cannot be found.
+   if ( ! IsConverged )
+   {
+      if ( MPI_Rank == 0 )
       {
-         if ( MPI_Rank == 0 )
-         {
-            printf("\n============================================================\n");
-            printf("GREP_CENTER_METHOD : %d\n",                   GREP_CENTER_METHOD);
-            printf("Center             : %13.7e %13.7e %13.7e\n", DensAve->Center[0], DensAve->Center[1], DensAve->Center[2]);
-            printf("MaxRadius          : %13.7e\n",               DensAve->MaxRadius);
-            printf("LogBin             : %d\n",                   DensAve->LogBin);
-            printf("LogBinRatio        : %13.7e\n",               DensAve->LogBinRatio);
-            printf("NBin               : %d\n",                   NBin);
-            printf("============================================================\n");
-            printf("%5s %9s %22s %22s %22s %22s %22s %22s %22s %22s %22s %22s\n",
-                   "Bin", "NCell", "Radius", "Dens", "Engy", "Vr", "Pressure",
-                   "Mass_NW", "Mass_TOV", "Mass_TOV_old", "Error_rel", "Gamma_TOV");
+         char FileName_GREP[50];
 
-            for (int i=0; i<NBin; i++)
-               printf("%5d %9ld %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e\n",
-                      i, DensAve->NCell[i], Radius[i],
-                      DensAve->Data[i], EngyAve->Data[i], VrAve->Data[i], PresAve->Data[i],
-                      Mass_NW[i], Mass_TOV[i], Mass_TOV_USG[i],
-                      FABS( Mass_TOV_USG[i] - Mass_TOV[i] ) / Mass_TOV[i], Gamma_TOV[i]);
+         sprintf( FileName_GREP, "GREP_Lv%02d_Debug", lv );
+         FILE *File_GREP = fopen( FileName_GREP, "w" );
 
-            Aux_Error( ERROR_INFO, "Too many iterations in constructing effective potential\n" );
-         }
+//       metadata
+         fprintf( File_GREP, "# Step               : %ld\n",                  Step );
+         fprintf( File_GREP, "# Time               : %.7e\n",                 Time );
+         fprintf( File_GREP, "# GREP_CENTER_METHOD : %d\n",                   GREP_CENTER_METHOD );
+         fprintf( File_GREP, "# Center             : %13.7e %13.7e %13.7e\n", DensAve->Center[0], DensAve->Center[1], DensAve->Center[2] );
+         fprintf( File_GREP, "# Maximum Radius     : %13.7e\n",               DensAve->MaxRadius );
+         fprintf( File_GREP, "# LogBin             : %d\n",                   DensAve->LogBin );
+         fprintf( File_GREP, "# LogBinRatio        : %13.7e\n",               DensAve->LogBinRatio );
+         fprintf( File_GREP, "# NBin               : %d\n",                   NBin );
+         fprintf( File_GREP, "# Maximum Iteration  : %d\n",                   NIter_Max );
+         fprintf( File_GREP, "# Tolerance          : %13.7e\n",               Tolerance );
+         fprintf( File_GREP, "------------------------------------------------------\n" );
+         fprintf( File_GREP, "%5s %9s %22s %22s %22s %22s %22s %22s %22s %22s %22s %22s\n",
+                             "# Bin", "NCell", "Radius", "Dens", "Engy", "Vr", "Pressure",
+                             "Mass_NW", "Mass_TOV", "Mass_TOV_Usg", "Gamma_TOV", "Rel_Err (Mass_TOV)");
+
+//       data
+         for (int i=0; i<NBin; i++)
+         fprintf( File_GREP, "%5d %9ld %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e\n",
+                             i, DensAve->NCell[i], Radius[i], Dens[i], Engy[i], Vr[i], Pres[i],
+                             Mass_NW[i], Mass_TOV[i], Mass_TOV_USG[i], Gamma_TOV[i],
+                             fabs( Mass_TOV_USG[i] - Mass_TOV[i] ) / Mass_TOV[i] );
+
+         fclose( File_GREP );
+
+//       terminate the program
+         Aux_Error( ERROR_INFO, "The solutions for Mass_TOV and Gamma_TOV are not converging !!\n" );
       }
+   } // if ( ! IsConverged )
 
-   } // while ( NIter-- )
 
-
-// copy Profile parameters to Phi_eff
+// 3. compute the effective GR potential at the bin center
    Phi_eff->NBin        = DensAve->NBin;
    Phi_eff->LogBin      = DensAve->LogBin;
    Phi_eff->LogBinRatio = DensAve->LogBinRatio;
    Phi_eff->MaxRadius   = DensAve->MaxRadius;
    Phi_eff->AllocateMemory();
-   for (int d=0; d<3; d++)               Phi_eff->Center[d] = DensAve->Center[d];
-   for (int b=0; b<Phi_eff->NBin; b++)   Phi_eff->Radius[b] = DensAve->Radius[b];
 
+   for (int d=0; d<3;    d++)   Phi_eff->Center[d] = DensAve->Center[d];
+   for (int b=0; b<NBin; b++)   Phi_eff->Radius[b] = DensAve->Radius[b];
 
-// compute effective potential at the bin center
-// set the outer boundary condition to be -M_grid / r_outer
+// set the outer boundary condition of the potential to -G * M_out / r_out
    Phi_eff->Data[NBin-1] = -NEWTON_G * ( Mass_TOV[NBin-1] - Mass_NW[NBin-1] ) / Radius[NBin-1];
 
    for (int i=NBin-2; i>0; i--)
    {
-      double dr          = Radius[i] - Radius[i+1];
-      double RadiusCubed = CUBE( Radius[i] );
+      double dr         = Radius[i] - Radius[i+1];
+      double Mass_NW_C  = 0.5 * ( Mass_NW[i] + Mass_NW[i-1] );
+      double Mass_TOV_C = ( 0.5 * ( Mass_TOV[i] + Mass_TOV[i-1] ) + FourPI * CUBE( Radius[i] ) * Pres[i] / c2 )
+                        * ( 1.0 + ( Engy[i] + Pres[i] ) / ( Dens[i] * c2 ) )
+                        / SQR( 0.5 * ( Gamma_TOV[i] + Gamma_TOV[i-1] ) );
 
-      double Mass_NW_rad  = 0.5 * ( Mass_NW[i] + Mass_NW[i-1] );
-
-      double Mass_TOV_rad = ( 0.5 * ( Mass_TOV[i] + Mass_TOV[i-1] ) + FourPI * RadiusCubed * PresAve->Data[i] / c2 )
-                          * ( 1.0 + ( EngyAve->Data[i] + PresAve->Data[i] ) / ( DensAve->Data[i] * c2 ) )
-                          / SQR( 0.5 * ( Gamma_TOV[i] + Gamma_TOV[i-1] ) );
-
-      Phi_eff->Data[i] = Phi_eff->Data[i+1] - dr * NEWTON_G * ( Mass_NW_rad - Mass_TOV_rad ) / SQR( Radius[i] );
+      Phi_eff->Data[i] = Phi_eff->Data[i+1] - dr * NEWTON_G * ( Mass_NW_C - Mass_TOV_C ) / SQR( Radius[i] );
    }
 
-   double dr           = Radius[0] - Radius[1];
-   double RadiusCubed  = CUBE( Radius[0] );
-   double Mass_NW_rad  = Mass_NW[0];
-   double Mass_TOV_rad = ( Mass_TOV[0] + FourPI * RadiusCubed * PresAve->Data[0] / c2 )
-                       * ( 1.0 + ( EngyAve->Data[0] + PresAve->Data[0] ) / ( DensAve->Data[0] * c2 ) )
-                       / SQR( Gamma_TOV[0] );
+   double dr         = Radius[0] - Radius[1];
+   double Mass_NW_C  = Mass_NW[0];
+   double Mass_TOV_C = ( Mass_TOV[0] + FourPI * CUBE( Radius[0] ) * Pres[0] / c2 )
+                     * ( 1.0 + ( Engy[0] + Pres[0] ) / ( Dens[0] * c2 ) )
+                     / SQR( Gamma_TOV[0] );
 
-   Phi_eff->Data[0] = Phi_eff->Data[1] - dr * NEWTON_G * ( Mass_NW_rad - Mass_TOV_rad ) / SQR( Radius[0] ) ;
+   Phi_eff->Data[0] = Phi_eff->Data[1] - dr * NEWTON_G * ( Mass_NW_C - Mass_TOV_C ) / SQR( Radius[0] ) ;
 
 
-#ifdef GAMER_DEBUG
+// Troubleshooting information
+#  ifdef GAMER_DEBUG
    if ( MPI_Rank == 0 )
    {
-      printf("\n============================================================\n");
-      printf("GREP_CENTER_METHOD : %d\n",                   GREP_CENTER_METHOD);
-      printf("Center             : %13.7e %13.7e %13.7e\n", Phi_eff->Center[0], Phi_eff->Center[1], Phi_eff->Center[2]);
-      printf("MaxRadius          : %13.7e\n",               Phi_eff->MaxRadius);
-      printf("LogBin             : %d\n",                   Phi_eff->LogBin);
-      printf("LogBinRatio        : %13.7e\n",               Phi_eff->LogBinRatio);
-      printf("Num of Iterations  : %d\n",                   GREP_MAXITER - NIter);
-      printf("NBin               : %d\n",                   NBin);
-      printf("============================================================\n");
-      printf("%5s %9s %22s %22s %22s %22s %22s %22s %22s %22s %23s\n",
-             "Bin", "NCell", "Radius", "Dens", "Engy", "Vr", "Pressure",
-             "Mass_NW", "Mass_TOV", "Gamma_TOV", "Eff_Pot");
+      char FileName_GREP[50];
 
+      sprintf( FileName_GREP, "GREP_Lv%02d", lv );
+      FILE *File_GREP = fopen( FileName_GREP, "w" );
+
+//    metadata
+      fprintf( File_GREP, "# Step               : %ld\n",                  Step );
+      fprintf( File_GREP, "# Time               : %.7e\n",                 Time );
+      fprintf( File_GREP, "# GREP_CENTER_METHOD : %d\n",                   GREP_CENTER_METHOD );
+      fprintf( File_GREP, "# Center             : %13.7e %13.7e %13.7e\n", Phi_eff->Center[0], Phi_eff->Center[1], Phi_eff->Center[2] );
+      fprintf( File_GREP, "# Maximum Radius     : %13.7e\n",               Phi_eff->MaxRadius );
+      fprintf( File_GREP, "# LogBin             : %d\n",                   Phi_eff->LogBin );
+      fprintf( File_GREP, "# LogBinRatio        : %13.7e\n",               Phi_eff->LogBinRatio );
+      fprintf( File_GREP, "# Num of Iteration   : %d\n",                   NIter );
+      fprintf( File_GREP, "# NBin               : %d\n",                   NBin );
+      fprintf( File_GREP, "# -----------------------------------------------\n" );
+      fprintf( File_GREP, "%5s %9s %22s %22s %22s %22s %22s %22s %22s %22s %23s\n",
+                          "# Bin", "NCell", "Radius", "Dens", "Engy", "Vr", "Pressure",
+                          "Mass_NW", "Mass_TOV", "Gamma_TOV", "Eff_Pot");
+
+//    data
       for (int i=0; i<NBin; i++)
-         printf("%5d %9ld %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %23.15e\n",
-                i, DensAve->NCell[i], Radius[i], DensAve->Data[i], EngyAve->Data[i], VrAve->Data[i], PresAve->Data[i],
-                Mass_NW[i], Mass_TOV[i], Gamma_TOV[i], Phi_eff->Data[i]);
+      fprintf( File_GREP, "%5d %9ld %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %22.15e %23.15e\n",
+                          i, DensAve->NCell[i], Radius[i], Dens[i], Engy[i], Vr[i], Pres[i],
+                          Mass_NW[i], Mass_TOV[i], Gamma_TOV[i], Phi_eff->Data[i] );
+
+      fclose( File_GREP );
    }
-#endif
+#  endif
 
 
 // free memory

--- a/src/SelfGravity/CPU_Poisson/CPU_ExtPot_GREP.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_ExtPot_GREP.cpp
@@ -109,23 +109,11 @@ void Init_GREP()
 
 
 // (3) initialize the GREP parameters
-   switch ( GREP_CENTER_METHOD )
-   {
-      case 1:
-         for (int i=0; i<3; i++)   GREP_Prof_Center[i] = amr->BoxCenter[i];
-      break;
-
-      default:
-         Aux_Error( ERROR_INFO, "incorrect parameter %s = %d !!\n", "GREP_CENTER_METHOD", GREP_CENTER_METHOD );
-   }
+//     --> GREP_Prof_Center will be reset in Poi_UserWorkBeforePoisson_GREP() at each global step
+   for (int i=0; i<3; i++)   GREP_Prof_Center[i] = amr->BoxCenter[i];
 
    GREP_Prof_MinBinSize = ( GREP_MINBINSIZE > 0.0 ) ? GREP_MINBINSIZE : amr->dh[MAX_LEVEL];
-
-   GREP_Prof_MaxRadius  = ( GREP_MAXRADIUS > 0.0 )
-                        ? GREP_MAXRADIUS
-                        : SQRT( SQR( MAX( amr->BoxSize[0] - GREP_Prof_Center[0], GREP_Prof_Center[0] ) )
-                        +       SQR( MAX( amr->BoxSize[1] - GREP_Prof_Center[1], GREP_Prof_Center[1] ) )
-                        +       SQR( MAX( amr->BoxSize[2] - GREP_Prof_Center[2], GREP_Prof_Center[2] ) ) );
+   GREP_Prof_MaxRadius  = ( GREP_MAXRADIUS  > 0.0 ) ? GREP_MAXRADIUS  : sqrt(3.0) * amr->BoxSize[0];
 
 
 // (4) allocate device and host memory for the GREP profiles in datatype of real

--- a/src/SelfGravity/CPU_Poisson/CPU_ExtPot_GREP.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_ExtPot_GREP.cpp
@@ -21,9 +21,7 @@ extern void **d_ExtPotGenePtr;
 extern int    GREP_LvUpdate;
 extern int    GREP_Sg     [NLEVEL];
 extern double GREP_SgTime [NLEVEL][2];
-extern double GREP_Prof_Center    [3];
-extern double GREP_Prof_MaxRadius;
-extern double GREP_Prof_MinBinSize;
+extern double GREP_Center [3];
 
 extern Profile_t *GREP_DensAve [NLEVEL+1][2];
 extern Profile_t *GREP_EngyAve [NLEVEL+1][2];
@@ -73,13 +71,11 @@ void Init_GREP_MemAllocate()
 // Function    :  Init_GREP
 // Description :  Initialize the GREP Profile_t objects and parameters
 //
-// Note        :  1. GREP_*Ave            : Profile_t objects storing the spherical-averaged profiles of
-//                                          density, energy, radial velocity, and pressure
-//                2. GREP_EffPot          : Profile_t objects storing the effective GR potential
-//                3. GREP_Sg              : Sandglass of the current profile data [0/1]
-//                4. GREP_SgTime          : Physical time of profile
-//                5. GREP_Prof_MinBinSize : Minimum bin size used to initialize the Profile_t object
-//                6. GREP_Prof_MaxRadius  : Maximum radius   used to initialize the Profile_t object
+// Note        :  1. GREP_*Ave   : Profile_t objects storing the spherically averaged profiles of
+//                                 density, energy, radial velocity, and pressure
+//                2. GREP_EffPot : Profile_t objects storing the effective GR potential
+//                3. GREP_Sg     : Sandglass of the current profile data [0/1]
+//                4. GREP_SgTime : Physical time of profile
 //-------------------------------------------------------------------------------------------------------
 void Init_GREP()
 {
@@ -108,11 +104,8 @@ void Init_GREP()
 
 
 // (3) initialize the GREP parameters
-//     --> GREP_Prof_Center will be reset in Poi_UserWorkBeforePoisson_GREP() at each global step
-   for (int i=0; i<3; i++)   GREP_Prof_Center[i] = amr->BoxCenter[i];
-
-   GREP_Prof_MinBinSize = ( GREP_MINBINSIZE > 0.0 ) ? GREP_MINBINSIZE : amr->dh[MAX_LEVEL];
-   GREP_Prof_MaxRadius  = ( GREP_MAXRADIUS  > 0.0 ) ? GREP_MAXRADIUS  : sqrt(3.0) * amr->BoxSize[0];
+//     --> GREP_Center will be reset in Poi_UserWorkBeforePoisson_GREP() at each sub-step
+   for (int i=0; i<3; i++)   GREP_Center[i] = amr->BoxCenter[i];
 
 
 // (4) allocate device and host memory for the GREP profiles in datatype of real
@@ -154,9 +147,9 @@ void SetExtPotAuxArray_GREP( double AuxArray_Flt[], int AuxArray_Int[], const do
    const int Sg_Lv   = GREP_Sg[Lv];
    const int Sg_FaLv = GREP_Sg[FaLv];
 
-   AuxArray_Flt[0] = GREP_Prof_Center[0];                       // x coordinate of the GREP profile center
-   AuxArray_Flt[1] = GREP_Prof_Center[1];                       // y coordinate of the GREP profile center
-   AuxArray_Flt[2] = GREP_Prof_Center[2];                       // z coordinate of the GREP profile center
+   AuxArray_Flt[0] = GREP_Center[0];                            // x coordinate of the GREP profile center
+   AuxArray_Flt[1] = GREP_Center[1];                            // y coordinate of the GREP profile center
+   AuxArray_Flt[2] = GREP_Center[2];                            // z coordinate of the GREP profile center
    AuxArray_Flt[3] = GREP_SgTime[ FaLv ][     Sg_FaLv ];        // new physical time of GREP on father level
    AuxArray_Flt[4] = GREP_SgTime[ FaLv ][ 1 - Sg_FaLv ];        // old physical time of GREP on father level
 

--- a/src/SelfGravity/CPU_Poisson/CPU_ExtPot_GREP.cpp
+++ b/src/SelfGravity/CPU_Poisson/CPU_ExtPot_GREP.cpp
@@ -19,17 +19,17 @@ extern void **d_ExtPotGenePtr;
 
        real  *h_ExtPotGREP;
 extern int    GREP_LvUpdate;
-extern int    GREPSg     [NLEVEL];
-extern double GREPSgTime [NLEVEL][2];
-extern double GREP_Prof_Center   [3];
+extern int    GREP_Sg     [NLEVEL];
+extern double GREP_SgTime [NLEVEL][2];
+extern double GREP_Prof_Center    [3];
 extern double GREP_Prof_MaxRadius;
 extern double GREP_Prof_MinBinSize;
 
-extern Profile_t *DensAve [NLEVEL+1][2];
-extern Profile_t *EngyAve [NLEVEL+1][2];
-extern Profile_t *VrAve   [NLEVEL+1][2];
-extern Profile_t *PresAve [NLEVEL+1][2];
-extern Profile_t *Phi_eff [NLEVEL  ][2];
+extern Profile_t *GREP_DensAve [NLEVEL+1][2];
+extern Profile_t *GREP_EngyAve [NLEVEL+1][2];
+extern Profile_t *GREP_VrAve   [NLEVEL+1][2];
+extern Profile_t *GREP_PresAve [NLEVEL+1][2];
+extern Profile_t *GREP_EffPot  [NLEVEL  ][2];
 
        void Init_GREP_MemAllocate();
        void End_ExtPot_GREP_MemFree();
@@ -73,12 +73,11 @@ void Init_GREP_MemAllocate()
 // Function    :  Init_GREP
 // Description :  Initialize the GREP Profile_t objects and parameters
 //
-// Note        :  1. DensAve, EngyAve, VrAve, and PresAve
-//                                        : Profile_t objects storing the spherical-averaged
-//                                          density, energy, radial velocity, and pressure.
-//                2. Phi_eff              : Profile_t objects storing the GR effective potential
-//                3. GREPSg               : Sandglass of the current profile data [0/1]
-//                4. GREPSgTime           : Physical time of profile
+// Note        :  1. GREP_*Ave            : Profile_t objects storing the spherical-averaged profiles of
+//                                          density, energy, radial velocity, and pressure
+//                2. GREP_EffPot          : Profile_t objects storing the effective GR potential
+//                3. GREP_Sg              : Sandglass of the current profile data [0/1]
+//                4. GREP_SgTime          : Physical time of profile
 //                5. GREP_Prof_MinBinSize : Minimum bin size used to initialize the Profile_t object
 //                6. GREP_Prof_MaxRadius  : Maximum radius   used to initialize the Profile_t object
 //-------------------------------------------------------------------------------------------------------
@@ -89,22 +88,22 @@ void Init_GREP()
    for (int Sg=0; Sg<2; Sg++)
    for (int lv=0; lv<=NLEVEL; lv++)
    {
-      DensAve [lv][Sg] = new Profile_t();
-      EngyAve [lv][Sg] = new Profile_t();
-      VrAve   [lv][Sg] = new Profile_t();
-      PresAve [lv][Sg] = new Profile_t();
+      GREP_DensAve [lv][Sg] = new Profile_t();
+      GREP_EngyAve [lv][Sg] = new Profile_t();
+      GREP_VrAve   [lv][Sg] = new Profile_t();
+      GREP_PresAve [lv][Sg] = new Profile_t();
 
       if ( lv < NLEVEL )
-      Phi_eff [lv][Sg] = new Profile_t();
+      GREP_EffPot  [lv][Sg] = new Profile_t();
    }
 
 
 // (2) initialize GREP Sg and SgTime
    for (int lv=0; lv<NLEVEL; lv++)
    {
-//    GREPSg must be initialized to [0/1]. Otherwise, it will fail when determining Sg in Poi_Prepare_GREP()
-      GREPSg[lv] = 0;
-      for (int Sg=0; Sg<2; Sg++)   GREPSgTime[lv][Sg] = -__FLT_MAX__;
+//    GREP_Sg must be initialized to [0/1]. Otherwise, it will fail when determining Sg in Poi_Prepare_GREP()
+      GREP_Sg[lv] = 0;
+      for (int Sg=0; Sg<2; Sg++)   GREP_SgTime[lv][Sg] = -__FLT_MAX__;
    }
 
 
@@ -152,18 +151,18 @@ void SetExtPotAuxArray_GREP( double AuxArray_Flt[], int AuxArray_Int[], const do
    const int Lv   = GREP_LvUpdate;
    const int FaLv = ( Lv > 0 ) ? Lv - 1 : Lv;
 
-   const int Sg_Lv   = GREPSg[Lv];
-   const int Sg_FaLv = GREPSg[FaLv];
+   const int Sg_Lv   = GREP_Sg[Lv];
+   const int Sg_FaLv = GREP_Sg[FaLv];
 
-   AuxArray_Flt[0] = GREP_Prof_Center[0];                   // x coordinate of the GREP profile center
-   AuxArray_Flt[1] = GREP_Prof_Center[1];                   // y coordinate of the GREP profile center
-   AuxArray_Flt[2] = GREP_Prof_Center[2];                   // z coordinate of the GREP profile center
-   AuxArray_Flt[3] = GREPSgTime[ FaLv ][     Sg_FaLv ];     // new physical time of GREP on father level
-   AuxArray_Flt[4] = GREPSgTime[ FaLv ][ 1 - Sg_FaLv ];     // old physical time of GREP on father level
+   AuxArray_Flt[0] = GREP_Prof_Center[0];                       // x coordinate of the GREP profile center
+   AuxArray_Flt[1] = GREP_Prof_Center[1];                       // y coordinate of the GREP profile center
+   AuxArray_Flt[2] = GREP_Prof_Center[2];                       // z coordinate of the GREP profile center
+   AuxArray_Flt[3] = GREP_SgTime[ FaLv ][     Sg_FaLv ];        // new physical time of GREP on father level
+   AuxArray_Flt[4] = GREP_SgTime[ FaLv ][ 1 - Sg_FaLv ];        // old physical time of GREP on father level
 
-   AuxArray_Int[0] = Phi_eff[ Lv   ][     Sg_Lv   ]->NBin;  // number of bin at new physical time on current level
-   AuxArray_Int[1] = Phi_eff[ FaLv ][     Sg_FaLv ]->NBin;  // number of bin at new physical time on  father level
-   AuxArray_Int[2] = Phi_eff[ FaLv ][ 1 - Sg_FaLv ]->NBin;  // number of bin at old physical time on  father level
+   AuxArray_Int[0] = GREP_EffPot[ Lv   ][     Sg_Lv   ]->NBin;  // number of bin at new physical time on current level
+   AuxArray_Int[1] = GREP_EffPot[ FaLv ][     Sg_FaLv ]->NBin;  // number of bin at new physical time on  father level
+   AuxArray_Int[2] = GREP_EffPot[ FaLv ][ 1 - Sg_FaLv ]->NBin;  // number of bin at old physical time on  father level
 
 } // FUNCTION : SetExtPotAuxArray_GREP
 #endif // #ifndef __CUDACC__
@@ -390,13 +389,13 @@ void End_ExtPot_GREP()
    for (int Sg=0; Sg<2; Sg++)
    for (int lv=0; lv<=NLEVEL; lv++)
    {
-      DensAve [lv][Sg]->FreeMemory();
-      EngyAve [lv][Sg]->FreeMemory();
-      VrAve   [lv][Sg]->FreeMemory();
-      PresAve [lv][Sg]->FreeMemory();
+      GREP_DensAve [lv][Sg]->FreeMemory();
+      GREP_EngyAve [lv][Sg]->FreeMemory();
+      GREP_VrAve   [lv][Sg]->FreeMemory();
+      GREP_PresAve [lv][Sg]->FreeMemory();
 
       if ( lv < NLEVEL )
-      Phi_eff [lv][Sg]->FreeMemory();
+      GREP_EffPot  [lv][Sg]->FreeMemory();
    }
 
    delete [] h_ExtPotGREP;  h_ExtPotGREP = NULL;

--- a/src/SelfGravity/Poi_UserWorkBeforePoisson_GREP.cpp
+++ b/src/SelfGravity/Poi_UserWorkBeforePoisson_GREP.cpp
@@ -283,15 +283,14 @@ void Poi_Prepare_GREP( const double Time, const int lv )
 
    if ( GREP_OPT_PRES == GREP_PRES_BINDATA )
    {
+#        ifdef YE
          real Passive[ NCOMP_TOTAL - NCOMP_FLUID ] = { 0.0 };
 
          for (int b=0; b<Dens_Tot->NBin; b++)
          {
             if ( Dens_Tot->NCell[b] == 0 )   continue;
 
-#           ifdef YE
             Passive[ YE - NCOMP_FLUID ] = Pres_Tot->Data[b];
-#           endif
 
 #           ifdef TEMP_IG
 //          set the initial guess of temperature to 1 MeV
@@ -304,6 +303,7 @@ void Poi_Prepare_GREP( const double Time, const int lv )
 
             Pres_Tot->Data[b] = Pres;
          }
+#        endif // ifdef YE
    } // if ( GREP_OPT_PRES == GREP_PRES_BINDATA )
 
 
@@ -378,10 +378,12 @@ void GREP_Compute_Profile( const int lv, const int Sg, const PatchType_t PatchTy
 
       case GREP_PRES_BINDATA:
       {
+#        ifdef YE
          long TVar[] = { _DENS, _VELR, _YE, _EINT };
 
          Aux_ComputeProfile( Prof_List, GREP_Prof_Center, GREP_Prof_MaxRadius, GREP_Prof_MinBinSize,
                              GREP_LOGBIN, GREP_LOGBINRATIO, RemoveEmpty_No, TVar, NVar, lv, lv, PatchType, PrepTime_No );
+#        endif
       }
       break;
 

--- a/src/SelfGravity/Poi_UserWorkBeforePoisson_GREP.cpp
+++ b/src/SelfGravity/Poi_UserWorkBeforePoisson_GREP.cpp
@@ -255,7 +255,7 @@ void Mis_UserWorkBeforeNextSubstep_GREP( const int lv, const double TimeNew, con
 void Poi_Prepare_GREP( const double Time, const int lv )
 {
 
-// compare the input time with the stored time to determine the appropriate SaveSg
+// compare the input time with the stored time to determine the appropriate sandglass
    int Sg;
 
    if      (  Mis_CompareRealValue( Time, GREP_SgTime[lv][0], NULL, false )  )   Sg = 0;
@@ -298,10 +298,8 @@ void Poi_Prepare_GREP( const double Time, const int lv )
             Passive[ TEMP_IG - NCOMP_FLUID ] = 1.0e6 / Const_kB_eV;
 #           endif
 
-            const real Pres = EoS_DensEint2Pres_CPUPtr( Dens_Tot->Data[b], Engy_Tot->Data[b],
-                                                        Passive, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
-
-            Pres_Tot->Data[b] = Pres;
+            Pres_Tot->Data[b] = EoS_DensEint2Pres_CPUPtr( Dens_Tot->Data[b], Engy_Tot->Data[b],
+                                                          Passive, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
          }
 #        endif // ifdef YE
    } // if ( GREP_OPT_PRES == GREP_PRES_BINDATA )

--- a/src/SelfGravity/Poi_UserWorkBeforePoisson_GREP.cpp
+++ b/src/SelfGravity/Poi_UserWorkBeforePoisson_GREP.cpp
@@ -240,8 +240,8 @@ void Poi_Prepare_GREP( const double Time, const int lv )
 
 
 // compute the effective GR potential
-   CPU_ComputeGREP( DensAve[NLEVEL][Sg], EngyAve[NLEVEL][Sg], VrAve[NLEVEL][Sg], PresAve[NLEVEL][Sg],
-                    Phi_eff[lv]    [Sg] );
+   CPU_ComputeGREP( lv, Time, DensAve[NLEVEL][Sg], EngyAve[NLEVEL][Sg],
+                    VrAve[NLEVEL][Sg], PresAve[NLEVEL][Sg], Phi_eff[lv][Sg] );
 
 } // FUNCTION : Poi_Prepare_GREP
 

--- a/src/SelfGravity/Poi_UserWorkBeforePoisson_GREP.cpp
+++ b/src/SelfGravity/Poi_UserWorkBeforePoisson_GREP.cpp
@@ -283,25 +283,25 @@ void Poi_Prepare_GREP( const double Time, const int lv )
 
    if ( GREP_OPT_PRES == GREP_PRES_BINDATA )
    {
-#        ifdef YE
-         real Passive[ NCOMP_TOTAL - NCOMP_FLUID ] = { 0.0 };
+#     ifdef YE
+      real Passive[ NCOMP_TOTAL - NCOMP_FLUID ] = { 0.0 };
 
-         for (int b=0; b<Dens_Tot->NBin; b++)
-         {
-            if ( Dens_Tot->NCell[b] == 0 )   continue;
+      for (int b=0; b<Dens_Tot->NBin; b++)
+      {
+         if ( Dens_Tot->NCell[b] == 0 )   continue;
 
-            Passive[ YE - NCOMP_FLUID ] = Pres_Tot->Data[b];
+         Passive[ YE - NCOMP_FLUID ] = Pres_Tot->Data[b];
 
-#           ifdef TEMP_IG
-//          set the initial guess of temperature to 1 MeV
+#        ifdef TEMP_IG
+//       set the initial guess of temperature to 1 MeV
 //###REVISE: implement support for Temp_IG from Aux_ComputeProfile()
-            Passive[ TEMP_IG - NCOMP_FLUID ] = 1.0e6 / Const_kB_eV;
-#           endif
+         Passive[ TEMP_IG - NCOMP_FLUID ] = 1.0e6 / Const_kB_eV;
+#        endif
 
-            Pres_Tot->Data[b] = EoS_DensEint2Pres_CPUPtr( Dens_Tot->Data[b], Engy_Tot->Data[b],
-                                                          Passive, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
-         }
-#        endif // ifdef YE
+         Pres_Tot->Data[b] = EoS_DensEint2Pres_CPUPtr( Dens_Tot->Data[b], Engy_Tot->Data[b],
+                                                       Passive, EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
+      }
+#     endif // ifdef YE
    } // if ( GREP_OPT_PRES == GREP_PRES_BINDATA )
 
 

--- a/src/TestProblem/Hydro/CCSN/Record_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/Record_CCSN.cpp
@@ -174,7 +174,7 @@ void Record_CCSN_CentralQuant()
 
       FILE *file_cent_quant = fopen( filename_central_quant, "a" );
 
-      fprintf( file_cent_quant, "%15.7e %12ld %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e",
+      fprintf( file_cent_quant, "%15.7e %12ld %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e",
                Time[0]*UNIT_T, Step, Data_Flt[1]*UNIT_L, Data_Flt[2]*UNIT_L, Data_Flt[3]*UNIT_L,
                u[DENS]*UNIT_D, Ye, CCSN_Rsh_Min*UNIT_L, CCSN_Rsh_Ave*UNIT_L, CCSN_Rsh_Max*UNIT_L );
 

--- a/src/TestProblem/Hydro/CCSN/Record_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/Record_CCSN.cpp
@@ -9,6 +9,7 @@ extern bool   CCSN_Is_PostBounce;
 extern double CCSN_Shock_ThresFac_Pres;
 extern double CCSN_Shock_ThresFac_Vel;
 extern int    CCSN_Shock_Weight;
+extern double GREP_Prof_Center[3];
 
 
 
@@ -143,9 +144,10 @@ void Record_CCSN_CentralQuant()
          else
          {
              FILE *file_cent_quant = fopen( filename_central_quant, "w" );
-             fprintf( file_cent_quant, "#%14s %12s %16s %16s %16s %16s %16s %16s %16s %16s\n",
+             fprintf( file_cent_quant, "#%14s %12s %16s %16s %16s %16s %16s %16s %16s %16s %16s %16s %16s\n",
                                        "1_Time [sec]", "2_Step", "3_PosX [cm]", "4_PosY [cm]", "5_PosZ [cm]",
-                                       "6_Dens [g/cm^3]", "7_Ye", "8_Rsh_Min [cm]", "9_Rsh_Ave [cm]", "10_Rsh_Max [cm]" );
+                                       "6_Dens [g/cm^3]", "7_Ye", "8_Rsh_Min [cm]", "9_Rsh_Ave [cm]", "10_Rsh_Max [cm]",
+                                       "11_GREP_PosX [cm]", "12_GREP_PosY [cm]", "13_GREP_PosZ [cm]" );
              fclose( file_cent_quant );
          }
 
@@ -169,9 +171,10 @@ void Record_CCSN_CentralQuant()
 #     endif
 
       FILE *file_cent_quant = fopen( filename_central_quant, "a" );
-      fprintf( file_cent_quant, "%15.7e %12ld %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e\n",
+      fprintf( file_cent_quant, "%15.7e %12ld %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e\n",
                Time[0]*UNIT_T, Step, Data_Flt[1]*UNIT_L, Data_Flt[2]*UNIT_L, Data_Flt[3]*UNIT_L,
-               u[DENS]*UNIT_D, Ye, CCSN_Rsh_Min*UNIT_L, CCSN_Rsh_Ave*UNIT_L, CCSN_Rsh_Max*UNIT_L );
+               u[DENS]*UNIT_D, Ye, CCSN_Rsh_Min*UNIT_L, CCSN_Rsh_Ave*UNIT_L, CCSN_Rsh_Max*UNIT_L,
+               GREP_Prof_Center[0]*UNIT_L, GREP_Prof_Center[1]*UNIT_L, GREP_Prof_Center[2]*UNIT_L );
       fclose( file_cent_quant );
 
    } // if ( MPI_Rank == 0 )

--- a/src/TestProblem/Hydro/CCSN/Record_CCSN.cpp
+++ b/src/TestProblem/Hydro/CCSN/Record_CCSN.cpp
@@ -9,7 +9,9 @@ extern bool   CCSN_Is_PostBounce;
 extern double CCSN_Shock_ThresFac_Pres;
 extern double CCSN_Shock_ThresFac_Vel;
 extern int    CCSN_Shock_Weight;
-extern double GREP_Prof_Center[3];
+#ifdef GRAVITY
+extern double GREP_Center[3];
+#endif
 
 
 
@@ -171,10 +173,21 @@ void Record_CCSN_CentralQuant()
 #     endif
 
       FILE *file_cent_quant = fopen( filename_central_quant, "a" );
-      fprintf( file_cent_quant, "%15.7e %12ld %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e\n",
+
+      fprintf( file_cent_quant, "%15.7e %12ld %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e %16.7e",
                Time[0]*UNIT_T, Step, Data_Flt[1]*UNIT_L, Data_Flt[2]*UNIT_L, Data_Flt[3]*UNIT_L,
-               u[DENS]*UNIT_D, Ye, CCSN_Rsh_Min*UNIT_L, CCSN_Rsh_Ave*UNIT_L, CCSN_Rsh_Max*UNIT_L,
-               GREP_Prof_Center[0]*UNIT_L, GREP_Prof_Center[1]*UNIT_L, GREP_Prof_Center[2]*UNIT_L );
+               u[DENS]*UNIT_D, Ye, CCSN_Rsh_Min*UNIT_L, CCSN_Rsh_Ave*UNIT_L, CCSN_Rsh_Max*UNIT_L );
+
+#     ifdef GRAVITY
+      fprintf( file_cent_quant, " %16.7e %16.7e %16.7e",
+               GREP_Center[0]*UNIT_L, GREP_Center[1]*UNIT_L, GREP_Center[2]*UNIT_L );
+#     else
+      fprintf( file_cent_quant, " %16.7e %16.7e %16.7e",
+               NULL_REAL, NULL_REAL, NULL_REAL );
+#     endif
+
+      fprintf( file_cent_quant, "\n" );
+
       fclose( file_cent_quant );
 
    } // if ( MPI_Rank == 0 )


### PR DESCRIPTION
- Refactoring `CPU_ComputeGREP()`
    - Dump the troubleshooting information into files
    - Correct `SQRT()` to `sqrt()` so that the potential would differ by ~1e-6 for single-precision runs
    
- Support different schemes for computing the pressure profile (`GREP_OPT_PRES`)
    - `GREP_OPT_PRES = 0`: individual cell
    - `GREP_OPT_PRES = 1`: binned data (default)
      - The pressure is computed after merging the profiles
      - The `Temp_IG` is set to 1 MeV when calling the EoS solver at now
      
- Support different definitions of GREP center (`GREP_CENTER_METHOD`)
    - `GREP_CENTER_METHOD = 0`: box center
    - `GREP_CENTER_METHOD = 1`: density maximum
      - Fixed the center to the box center during the collapse phase in CCSN simulations
    - `GREP_CENTER_METHOD = 2`: potential minimum (default)
    - `GREP_CENTER_METHOD = 3`: CoM (to be supported in future)
    - For `GREP_CENTER_METHOD = 1/2`, the center is shifted to the box center if it coincides with one of the innermost cells

- Set `Vr = 0` if `r = 0` in `Aux_ComputeProfile()`

- Check the GREP profiles before computing the potential, and terminate the program if any unphysical bins are present

- Set the default `GREP_Prof_MaxRadius` to `sqrt(3) * BOX_SIZE` to ensure a consistent bin number when merging profiles