### PR TITLE
Enable matrix multiplication in GRAMFE_MATMUL algorithm in single precision

### DIFF
--- a/include/Macro.h
+++ b/include/Macro.h
@@ -917,7 +917,7 @@
 #   define GRAMFE_FFT_FLOAT8
 #endif
 
-#if ( GRAMFE_SCHEME == GRAMFE_MATMUL )
+#if ( ( GRAMFE_SCHEME == GRAMFE_MATMUL ) && defined( FLOAT8 ) )
 #   define GRAMFE_MATMUL_FLOAT8
 #endif
 

--- a/src/Model_ELBDM/ELBDM_GramFE_EvolutionMatrix.cpp
+++ b/src/Model_ELBDM/ELBDM_GramFE_EvolutionMatrix.cpp
@@ -95,8 +95,8 @@ void ELBDM_GramFE_ComputeTimeEvolutionMatrix( gramfe_matmul_float (*output)[2 * 
    long double K, Filter, Coeff;
    gramfe_evo_complex_type ExpCoeff;
 
-   const long double filterDecay  = (long double) 32.0 * (long double) 2.302585092994046; // decay of k-space filter ( 32 * log(10) )
-   const long double filterDegree = (long double) 100;                                    // degree of k-space filter
+   const long double filterDecay  = (long double) 16.0 * (long double) 2.302585092994046; // decay of k-space filter ( 16 * log(10) )
+   const long double filterDegree = (long double) 50;                                     // degree of k-space filter
    const long double kmax         = (long double) M_PI / dh;                              // maximum value of k
    const long double dk           = (long double) + 2.0 * kmax / GRAMFE_FLU_NXT;          // k steps in k-space
    const long double dT           = (long double) - 0.5 * dt / Eta;                       // coefficient in time evolution operator


### PR DESCRIPTION
- Change filter parameters from `exp(-log(10*32) * (k/k_max)^100)` to `exp(-log(10*16) * (k/k_max)^50)`
- These parameters are not a unique choice. The important change is that the exponent is smaller so that slightly lower frequencies are filtered which seems to make the difference between stability and instability
- My tests indicate that this choice of parameters does not make `GRAMFE_FFT` stable
- Enable single precision GRAMFE_MATMUL algorithm if `FLOAT8` is not defined, use double precision if `FLOAT8` is defined
- Stability tests indicate stability up to `DT__FLUID = 0.25`, retain default of `DT__FLUID = 0.2`