### PR TITLE
add a check for pressure in interpolation

### DIFF
--- a/src/Interpolation/Interpolate.cpp
+++ b/src/Interpolation/Interpolate.cpp
@@ -362,6 +362,7 @@ void Interpolate_Iterate( real CData[], const int CSize[3], const int CStart[3],
 
 //       5-3. additional check
          real Eint=NULL_REAL;
+         real Pres=NULL_REAL;
 
          if ( !Fail_ThisCell )
          {
@@ -383,10 +384,16 @@ void Interpolate_Iterate( real CData[], const int CSize[3], const int CStart[3],
 
                   Eint = EoS_DensPres2Eint_CPUPtr( Temp[DENS], Temp[ENGY], Passive,
                                                    EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
+                  Pres = EoS_DensEint2Pres_CPUPtr( Temp[DENS], Eint,       Passive,
+                                                   EoS_AuxArray_Flt, EoS_AuxArray_Int, h_EoS_Table );
 
 //                internal energy cannot be negative (even within machine precision) since a pressure floor has been applied
 //                when calling Hydro_Con2Pri()
                   if (  Hydro_IsUnphysical_Single( Eint, "interpolated internal energy", (real)0.0, HUGE_NUMBER,
+                                                   ERROR_INFO, UNPHY_SILENCE )  )
+                     Fail_ThisCell = true;
+
+                  if (  Hydro_IsUnphysical_Single( Pres, "interpolated pressure",        (real)0.0, HUGE_NUMBER,
                                                    ERROR_INFO, UNPHY_SILENCE )  )
                      Fail_ThisCell = true;
                } // if ( EoS_DensPres2Eint_CPUPtr != NULL )


### PR DESCRIPTION
Adding a check for pressure in interpolation.

This can catch the failure when the pressure mode in EoS is stable, but not energy mode.